### PR TITLE
JSON v1 compatibility and formatting

### DIFF
--- a/src/atomcutoffs.jl
+++ b/src/atomcutoffs.jl
@@ -19,46 +19,46 @@ const AbstractCutoff = Union{SphericalCutoff,EllipsoidCutoff}
 
 env_cutoff(sc::SphericalCutoff) = sc.rcut
 env_filter(r::T, cutoff::SphericalCutoff) where {T<:Real} = (r <= cutoff.rcut)
-env_filter(r::StaticVector{3,T}, cutoff::SphericalCutoff) where {T<:Real} = (sum(r.^2) <= cutoff.rcut^2)
+env_filter(r::StaticVector{3,T}, cutoff::SphericalCutoff) where {T<:Real} = (sum(r .^ 2) <= cutoff.rcut^2)
 
 """
     maps environment to unit-sphere
-    env_transform(Rs::AbstractVector{<: SVector}, 
-    Zs::AbstractVector{<: AtomicNumber}, 
+    env_transform(Rs::AbstractVector{<: SVector},
+    Zs::AbstractVector{<: AtomicNumber},
     sc::DSphericalCutoff, filter=false)
 
 """
-function env_transform(Rs::AbstractVector{<: SVector}, 
-    Zs::AbstractVector{<: AtomicNumber}, 
+function env_transform(Rs::AbstractVector{<:SVector},
+    Zs::AbstractVector{<:AtomicNumber},
     sc::SphericalCutoff)
-    cfg =  [ ACEfrictionCore.State(rr = r/sc.rcut, mu = chemical_symbol(z))  for (r,z) in zip( Rs,Zs) ] |> ACEConfig
+    cfg = [ACEfrictionCore.State(rr=r / sc.rcut, mu=chemical_symbol(z)) for (r, z) in zip(Rs, Zs)] |> ACEConfig
     return cfg
 end
 """
     maps environment to unit-sphere and labels j th particle as :bond
-    env_transform(Rs::AbstractVector{<: SVector}, 
-    Zs::AbstractVector{<: AtomicNumber}, 
+    env_transform(Rs::AbstractVector{<: SVector},
+    Zs::AbstractVector{<: AtomicNumber},
     sc::DSphericalCutoff, filter=false)
 
 """
-function env_transform(j::Int, 
-    Rs::AbstractVector{<: SVector}, 
-    Zs::AbstractVector{<: AtomicNumber}, 
+function env_transform(j::Int,
+    Rs::AbstractVector{<:SVector},
+    Zs::AbstractVector{<:AtomicNumber},
     dse::SphericalCutoff)
     # Y0 = State( rr = rrij, mube = :bond) # Atomic species of bond atoms does not matter at this stage.
     # cfg = Vector{typeof(Y0)}(undef, length(Rs)+1)
     # cfg[1] = Y0
-    cfg = [State( rr = Rs[l]/dse.rcut, mube = (l == j ? :bond : chemical_symbol(Zs[l])) ) for l = eachindex(Rs)] |> ACEConfig
-    return cfg 
+    cfg = [State(rr=Rs[l] / dse.rcut, mube=(l == j ? :bond : chemical_symbol(Zs[l]))) for l = eachindex(Rs)] |> ACEConfig
+    return cfg
 end
 
 function ACEfrictionCore.write_dict(cutoff::SphericalCutoff{T}) where {T}
     return Dict("__id__" => "ACEfriction_SphericalCutoff",
-          "rcut" => cutoff.rcut,
-             "T" => T)         
-end 
+        "rcut" => cutoff.rcut,
+        "T" => T)
+end
 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_SphericalCutoff}, D::Dict)
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_SphericalCutoff}, D::AbstractDict)
     T = getfield(Base, Symbol(D["T"]))
     rcut = T(D["rcut"])
     return SphericalCutoff(rcut)

--- a/src/frictionmodels.jl
+++ b/src/frictionmodels.jl
@@ -22,7 +22,7 @@ abstract type AbstractFrictionModel end
 """
     FrictionModel{MODEL_IDS}
 
-A friction model is a wrapper for a collection of matrix models with "IDs" listed in the tuple `MODEL_IDS`. 
+A friction model is a wrapper for a collection of matrix models with "IDs" listed in the tuple `MODEL_IDS`.
 When evaluated at an atomic configuration, the resulting friction tensor is the sum of the friction tensors of all matrix models in the friction model.
 
 ### Fields:
@@ -30,7 +30,7 @@ When evaluated at an atomic configuration, the resulting friction tensor is the 
 
 """
 struct FrictionModel{MODEL_IDS} <: AbstractFrictionModel
-    matrixmodels::NamedTuple{MODEL_IDS} 
+    matrixmodels::NamedTuple{MODEL_IDS}
 end
 
 """
@@ -53,20 +53,20 @@ Evaluates the friction tensor according to the friction model `fm` at the atomic
 
 - `fm` -- the friction model of which the friction tensor is evaluated.
 - `at` -- the atomic configuration at which the basis is evaluated
-- `filter`  -- (optional, default: `(_,_)->true`) a filter function of the generic form `(i::Int,at::Atoms) -> Bool`. Only atoms `at[i]` for which `filter(i,at)` returns `true` are included in the evaluation of the friction tensor.  
+- `filter`  -- (optional, default: `(_,_)->true`) a filter function of the generic form `(i::Int,at::Atoms) -> Bool`. Only atoms `at[i]` for which `filter(i,at)` returns `true` are included in the evaluation of the friction tensor.
 
 ### Output:
 
-A friction tensor in the form of a sparse 3N x 3N matrix, where N is the number of atoms in the atomic configuration `at`.  
+A friction tensor in the form of a sparse 3N x 3N matrix, where N is the number of atoms in the atomic configuration `at`.
 """
-function Gamma(fm::FrictionModel, at::Atoms; filter=(_,_)->true, T=Float64) 
+function Gamma(fm::FrictionModel, at::Atoms; filter=(_, _) -> true, T=Float64)
     return sum(Gamma(mo, at; filter=filter, T=T) for mo in values(fm.matrixmodels))
 end
 
 """
     Gamma(fm::FrictionModel{MODEL_IDS}, Σ_vec::NamedTuple{MODEL_IDS}) where {MODEL_IDS}
 
-Computes the friction tensor from a pre-computed collection of diffusion coefficient matrices. 
+Computes the friction tensor from a pre-computed collection of diffusion coefficient matrices.
 The friction tensor is the sum of the squares of all diffusion coefficient matrices in the collection.
 
 ### Arguments:
@@ -77,8 +77,8 @@ The friction tensor is the sum of the squares of all diffusion coefficient matri
 
 A friction tensor in the form of a sparse 3N x 3N matrix, where N is the number of atoms in the atomic configuration `at`.  The friction tensor is the sum of the symmetric squares ``\\Sigma\\Sigma^T`` of all diffusion coefficient matrices ``\\Sigma`` in `Σ_vec`.
 """
-function Gamma(fm::FrictionModel{MODEL_IDS}, Σ::NamedTuple{MODEL_IDS}) where {MODEL_IDS} 
-    return sum(Gamma(mo, sΣ) for (mo,sΣ) in zip(values(fm.matrixmodels),Σ))
+function Gamma(fm::FrictionModel{MODEL_IDS}, Σ::NamedTuple{MODEL_IDS}) where {MODEL_IDS}
+    return sum(Gamma(mo, sΣ) for (mo, sΣ) in zip(values(fm.matrixmodels), Σ))
     #+ Gamma(fm.inv, at; kvargs...)
 end
 
@@ -95,8 +95,8 @@ Generates a ``{\\rm Normal}({\\bm 0}, {\\bm \\Gamma})``-distributed Gaussian pse
 
 A ``{\\rm Normal}({\\bm 0}, {\\bm \\Gamma})``-distributed Gaussian vector `R::Vector{3,Float64}` of length N, where N is the number of atoms in the configuration for which `Σ` was evaluated.
 """
-function randf(fm::FrictionModel{MODEL_IDS}, Σ::NamedTuple{MODEL_IDS}) where {MODEL_IDS} 
-    return sum(ACEfriction.MatrixModels.randf(mo,sΣ) for (mo,sΣ) in zip(values(fm.matrixmodels),Σ))
+function randf(fm::FrictionModel{MODEL_IDS}, Σ::NamedTuple{MODEL_IDS}) where {MODEL_IDS}
+    return sum(ACEfriction.MatrixModels.randf(mo, sΣ) for (mo, sΣ) in zip(values(fm.matrixmodels), Σ))
 end
 
 """
@@ -115,7 +115,7 @@ Computes the diffusion coefficient matrices for all matrix models in the frictio
 A NamedTuple of diffusion coefficient matrices, where the keys are the IDs of the matrix models in the friction model.
 
 """
-function Sigma(fm::FrictionModel{MODEL_IDS}, at::Atoms; filter=(_,_)->true, T=Float64) where {MODEL_IDS}
+function Sigma(fm::FrictionModel{MODEL_IDS}, at::Atoms; filter=(_, _) -> true, T=Float64) where {MODEL_IDS}
     return NamedTuple{MODEL_IDS}(Sigma(mo, at; filter=filter, T=T) for mo in values(fm.matrixmodels))
 end
 
@@ -129,9 +129,9 @@ Evaluates the ACE-basis functions of the friction model `fm` at the atomic confi
 - `fm` -- the friction model of which the basis is evaluated
 - `at` -- the atomic configuration at which the basis is evaluated
 - `join_sites` -- (optional, default: `false`) if `true`, the basis evaulations of all matrix models are concatenated into a single array. If `false`, the basis evaluations are returned as a named tuple of the type `NamedTuple{MODEL_IDS}`.
-- `filter`  -- (optional, default: `(_,_)->true`) a filter function of the generic form `(i::Int,at::Atoms) -> Bool`. The atom `at[i]` will be included in the basis iff `filter(i,at)` returns `true`.  
+- `filter`  -- (optional, default: `(_,_)->true`) a filter function of the generic form `(i::Int,at::Atoms) -> Bool`. The atom `at[i]` will be included in the basis iff `filter(i,at)` returns `true`.
 """
-function basis(fm::FrictionModel{MODEL_IDS}, at::Atoms; join_sites=false, filter=(_,_)->true, T=Float64) where {MODEL_IDS}
+function basis(fm::FrictionModel{MODEL_IDS}, at::Atoms; join_sites=false, filter=(_, _) -> true, T=Float64) where {MODEL_IDS}
     return NamedTuple{MODEL_IDS}(basis(mo, at; join_sites=join_sites, filter=filter, T=T) for mo in values(fm.matrixmodels))
     #return Dict(key => basis(mo, at; kvargs...) for (key,mo) in fm.matrixmodels)
 end
@@ -153,7 +153,7 @@ Returns the parameters of all matrix models in the FrictionModel object as a Nam
 """
 function params(fm::FrictionModel{MODEL_IDS}; format=:matrix, joinsites=true) where {MODEL_IDS}
     #model_ids = map(Symbol,(s for s in keys(fm.matrixmodels)))
-    return NamedTuple{MODEL_IDS}(params(fm.matrixmodels[s]; joinsites=joinsites,format=format) for s in MODEL_IDS)
+    return NamedTuple{MODEL_IDS}(params(fm.matrixmodels[s]; joinsites=joinsites, format=format) for s in MODEL_IDS)
 end
 
 """
@@ -171,41 +171,41 @@ end
 Sets the parameters of all matrix models in the FrictionModel object whose ID is contained in `θ::NamedTuple` to the values specified therein.
 """
 function ACEfrictionCore.set_params!(fm::FrictionModel, θ::NamedTuple)
-    for s in keys(θ) 
+    for s in keys(θ)
         ACEfrictionCore.set_params!(fm.matrixmodels[s], θ[s])
     end
 end
 
-get_ids(::FrictionModel{MODEL_IDS})  where {MODEL_IDS} = MODEL_IDS
+get_ids(::FrictionModel{MODEL_IDS}) where {MODEL_IDS} = MODEL_IDS
 
 function ACEfrictionCore.scaling(fm::FrictionModel{MODEL_IDS}, p::Int) where {MODEL_IDS}
-    return NamedTuple{MODEL_IDS}( ACEfrictionCore.scaling(mo,p) for mo in values(fm.matrixmodels))
+    return NamedTuple{MODEL_IDS}(ACEfrictionCore.scaling(mo, p) for mo in values(fm.matrixmodels))
 end
 
-function Gamma(M::MatrixModel, at::Atoms; kvargs...) 
-    Σ_vec = Sigma(M, at; kvargs...) 
-    return sum(_square(Σ,M) for Σ in Σ_vec)
+function Gamma(M::MatrixModel, at::Atoms; kvargs...)
+    Σ_vec = Sigma(M, at; kvargs...)
+    return sum(_square(Σ, M) for Σ in Σ_vec)
 end
 
-function Gamma(M::MatrixModel, Σ_vec) 
-    return sum(_square(Σ,M) for Σ in Σ_vec)
+function Gamma(M::MatrixModel, Σ_vec)
+    return sum(_square(Σ, M) for Σ in Σ_vec)
 end
 
 
-_square(Σ, ::MatrixModel) = Σ*transpose(Σ)
+_square(Σ, ::MatrixModel) = Σ * transpose(Σ)
 
-function _square(Σ::SparseMatrixCSC{Tv,Ti}, ::PWCMatrixModel) where {Tv, Ti}
-    nvals = 2*length(Σ.nzval) #+ length(Σ.m)
+function _square(Σ::SparseMatrixCSC{Tv,Ti}, ::PWCMatrixModel) where {Tv,Ti}
+    nvals = 2 * length(Σ.nzval) #+ length(Σ.m)
     Is, Js, Vs = findnz(Σ)
-    I, J, V = Ti[],Ti[],SMatrix{3, 3,eltype(Tv), 9}[]
+    I, J, V = Ti[], Ti[], SMatrix{3,3,eltype(Tv),9}[]
     sizehint!(J, nvals)
     sizehint!(V, nvals)
-    #k = 1 
-    for (i,j,σij) in zip(Is, Js, Vs)
+    #k = 1
+    for (i, j, σij) in zip(Is, Js, Vs)
         if i <= j
-            σji = Σ[j,i]
+            σji = Σ[j, i]
             push!(I, i)
-            push!(J,j)
+            push!(J, j)
             push!(V, σij * σji')
 
             push!(I, j)
@@ -214,11 +214,11 @@ function _square(Σ::SparseMatrixCSC{Tv,Ti}, ::PWCMatrixModel) where {Tv, Ti}
 
             push!(I, i)
             push!(J, i)
-            push!(V, σij* σij')
+            push!(V, σij * σij')
 
             push!(I, j)
             push!(J, j)
-            push!(V, σji* σji')
+            push!(V, σji * σji')
         end
     end
     A = sparse(I, J, V, Σ.m, Σ.n)
@@ -227,19 +227,19 @@ end
 
 
 # using Tullio
-# function Gamma(M::MatrixModel{VectorEquivariant}, at::Atoms; kvargs...) 
-#     Σ_vec = Sigma(M, at; kvargs...) 
+# function Gamma(M::MatrixModel{VectorEquivariant}, at::Atoms; kvargs...)
+#     Σ_vec = Sigma(M, at; kvargs...)
 #     return sum(@tullio Γ[i,j] :=  Σ[i,k] * transpose(Σ[j,k]) for Σ in Σ_vec)
 # end
 
-Sigma(M::MatrixModel, at::Atoms; kvargs...) = matrix(M, at; kvargs...) 
+Sigma(M::MatrixModel, at::Atoms; kvargs...) = matrix(M, at; kvargs...)
 
 function ACEfrictionCore.write_dict(fm::FrictionModel)
     return Dict("__id__" => "ACEfriction_FrictionModel",
-          "matrixmodels" => Dict(id=>write_dict(fm.matrixmodels[id]) for id in keys(fm.matrixmodels)))        
-end 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_FrictionModel}, D::Dict)
-    matrixmodels = NamedTuple(Dict(Symbol(id)=>read_dict(val) for (id,val) in D["matrixmodels"]))
+        "matrixmodels" => Dict(id => write_dict(fm.matrixmodels[id]) for id in keys(fm.matrixmodels)))
+end
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_FrictionModel}, D::AbstractDict)
+    matrixmodels = NamedTuple(Dict(Symbol(id) => read_dict(val) for (id, val) in D["matrixmodels"]))
     return FrictionModel(matrixmodels)
 end
 

--- a/src/input-output.jl
+++ b/src/input-output.jl
@@ -6,10 +6,10 @@ using ACEfriction.MatrixModels: RWCMatrixModel
 
 
 
- 
- 
 
- 
+
+
+
 
 
 
@@ -18,18 +18,18 @@ using ACEfriction.MatrixModels: RWCMatrixModel
 #     Dict("__id__" => "ACE_AntiSymmetricEuclideanMatrix",
 #           "valr" => write_dict(real.(Matrix(φ.val))),
 #           "vali" => write_dict(imag.(Matrix(φ.val))),
-#              "T" => write_dict(T))         
+#              "T" => write_dict(T))
 #  end
 
 
-#  function ACE.read_dict(::Val{:ACE_SymmetricEuclideanMatrix}, D::Dict)
+#  function ACE.read_dict(::Val{:ACE_SymmetricEuclideanMatrix}, D::AbstractDict)
 #     T = read_dict(D["T"])
 #     valr = SMatrix{3, 3, T, 9}(read_dict(D["valr"]))
 #     vali = SMatrix{3, 3, T, 9}(read_dict(D["vali"]))
 #     return SymmetricEuclideanMatrix{T}(valr + im * vali)
 #  end
- 
-#  function ACE.read_dict(::Val{:ACE_AntiSymmetricEuclideanMatrix}, D::Dict)
+
+#  function ACE.read_dict(::Val{:ACE_AntiSymmetricEuclideanMatrix}, D::AbstractDict)
 #     T = read_dict(D["T"])
 #     valr = SMatrix{3, 3, T, 9}(read_dict(D["valr"]))
 #     vali = SMatrix{3, 3, T, 9}(read_dict(D["vali"]))

--- a/src/matrixmodels/acmatrixmodels.jl
+++ b/src/matrixmodels/acmatrixmodels.jl
@@ -5,23 +5,23 @@ struct RWCMatrixModel{O3S,CUTOFF,EVALCENTER} <: MatrixModel{O3S}
     n_rep::Int
     inds::SiteInds
     id::Symbol
-    function RWCMatrixModel(onsite::OnSiteModels{O3S}, offsite::OffSiteModels{O3S,Z2S,CUTOFF}, id::Symbol, ::EVALCENTER) where {O3S,Z2S, CUTOFF<:SphericalCutoff, EVALCENTER<:Union{NeighborCentered,AtomCentered}}
+    function RWCMatrixModel(onsite::OnSiteModels{O3S}, offsite::OffSiteModels{O3S,Z2S,CUTOFF}, id::Symbol, ::EVALCENTER) where {O3S,Z2S,CUTOFF<:SphericalCutoff,EVALCENTER<:Union{NeighborCentered,AtomCentered}}
         _assert_offsite_keys(offsite, SpeciesUnCoupled())
-        @assert _n_rep(onsite) ==  _n_rep(offsite)
-        @assert length(unique([mo.cutoff for mo in values(offsite)])) == 1 
-        @assert length(unique([mo.cutoff for mo in values(onsite)])) == 1 
+        @assert _n_rep(onsite) == _n_rep(offsite)
+        @assert length(unique([mo.cutoff for mo in values(offsite)])) == 1
+        @assert length(unique([mo.cutoff for mo in values(onsite)])) == 1
         #@assert all([z1 in keys(onsite), z2 in keys(offsite)  for (z1,z2) in zzkeys])
         return new{O3S,CUTOFF,EVALCENTER}(onsite, offsite, _n_rep(onsite), SiteInds(_get_basisinds(onsite), _get_basisinds(offsite)), id)
     end
 end #TODO: Add proper constructor that checks for correct Species evalcenter
 
 function ACEfrictionCore.set_params!(mb::RWCMatrixModel, θ::NamedTuple)
-    ACEfrictionCore.set_params!(mb, :onsite,  θ.onsite)
+    ACEfrictionCore.set_params!(mb, :onsite, θ.onsite)
     ACEfrictionCore.set_params!(mb, :offsite, θ.offsite)
 end
 
 function ACEfrictionCore.set_params!(mb::RWCMatrixModel, θ)
-    θt = _split_sites(mb, θ) 
+    θt = _split_sites(mb, θ)
     ACEfrictionCore.set_params!(mb::RWCMatrixModel, θt)
 end
 
@@ -29,15 +29,15 @@ function set_params!(mb::RWCMatrixModel, site::Symbol, θ)
     θt = _rev_transform(θ, mb.n_rep)
     sitedict = getfield(mb, site)
     for z in keys(sitedict)
-        ACEfrictionCore.set_params!(_get_model(mb,z),θt[get_range(mb,z)]) 
+        ACEfrictionCore.set_params!(_get_model(mb, z), θt[get_range(mb, z)])
     end
 end
 
-_index_map(i,j, ::RWCMatrixModel{O3S,CUTOFF,AtomCentered}) where {O3S,CUTOFF} = i,j
-_index_map(i,j, ::RWCMatrixModel{O3S,CUTOFF,NeighborCentered}) where {O3S,CUTOFF} = j,i 
+_index_map(i, j, ::RWCMatrixModel{O3S,CUTOFF,AtomCentered}) where {O3S,CUTOFF} = i, j
+_index_map(i, j, ::RWCMatrixModel{O3S,CUTOFF,NeighborCentered}) where {O3S,CUTOFF} = j, i
 
-function matrix!(M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms, Σ, filter=(_,_)->true) where {O3S,EVALCENTER}
-    site_filter(i,at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
+function matrix!(M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms, Σ, filter=(_, _) -> true) where {O3S,EVALCENTER}
+    site_filter(i, at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
     for (i, neigs, Rs) in sites(at, env_cutoff(M.onsite))
         if site_filter(i, at) && length(neigs) > 0
             # evaluate onsite model
@@ -45,18 +45,18 @@ function matrix!(M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms,
             sm = _get_model(M, at.Z[i])
             #cfg = env_transform(Rs, Zs, sm.cutoff)
             Σ_temp = evaluate(sm, Rs, Zs)
-            for r=1:M.n_rep
-                Σ[r][i,i] += _val2block(M, Σ_temp[r].val)
+            for r = 1:M.n_rep
+                Σ[r][i, i] += _val2block(M, Σ_temp[r].val)
             end
             # evaluate offsite model
             for (j_loc, j) in enumerate(neigs) #rij, riι
-                Zi, Zj = at.Z[i],at.Z[j]
-                if haskey(M.offsite,(Zi,Zj))
-                    sm = M.offsite[(Zi,Zj)]
+                Zi, Zj = at.Z[i], at.Z[j]
+                if haskey(M.offsite, (Zi, Zj))
+                    sm = M.offsite[(Zi, Zj)]
                     cfg = env_transform(j_loc, Rs, Zs, sm.cutoff)
                     Σ_temp = evaluate(sm.linmodel, cfg)
-                    for r=1:M.n_rep
-                        Σ[r][_index_map(i,j, M)...] += _val2block(M, Σ_temp[r].val)
+                    for r = 1:M.n_rep
+                        Σ[r][_index_map(i, j, M)...] += _val2block(M, Σ_temp[r].val)
                     end
                 end
             end
@@ -64,8 +64,8 @@ function matrix!(M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms,
     end
 end
 
-function basis!(B, M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms, filter=(_,_)->true) where {O3S,EVALCENTER} # Todo change type of B to NamedTuple{(:onsite,:offsite)} 
-    site_filter(i,at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
+function basis!(B, M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atoms, filter=(_, _) -> true) where {O3S,EVALCENTER} # Todo change type of B to NamedTuple{(:onsite,:offsite)}
+    site_filter(i, at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
     for (i, neigs, Rs) in sites(at, env_cutoff(M.onsite))
         if site_filter(i, at) && length(neigs) > 0
             # evaluate basis of onsite model
@@ -73,18 +73,18 @@ function basis!(B, M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atom
             sm = _get_model(M, at.Z[i])
             inds = get_range(M, at.Z[i])
             Bii = evaluate(sm.linmodel.basis, env_transform(Rs, Zs, sm.cutoff))
-            for (k,b) in zip(inds,Bii)
-                B.onsite[k][i,i] += _val2block(M, b.val)
+            for (k, b) in zip(inds, Bii)
+                B.onsite[k][i, i] += _val2block(M, b.val)
             end
             for (j_loc, j) in enumerate(neigs)
-                Zi, Zj = at.Z[i],at.Z[j]
-                if haskey(M.offsite,(Zi,Zj))
-                    sm = M.offsite[(Zi,Zj)]
-                    inds = get_range(M, (Zi,Zj))
+                Zi, Zj = at.Z[i], at.Z[j]
+                if haskey(M.offsite, (Zi, Zj))
+                    sm = M.offsite[(Zi, Zj)]
+                    inds = get_range(M, (Zi, Zj))
                     cfg = env_transform(j_loc, Rs, Zs, sm.cutoff)
                     Bij = evaluate(sm.linmodel.basis, cfg)
-                    for (k,b) in zip(inds, Bij)
-                        B.offsite[k][_index_map(i,j, M)...] += _val2block(M, b.val)
+                    for (k, b) in zip(inds, Bij)
+                        B.offsite[k][_index_map(i, j, M)...] += _val2block(M, b.val)
                     end
                 end
             end
@@ -92,37 +92,37 @@ function basis!(B, M::RWCMatrixModel{O3S,<:SphericalCutoff,EVALCENTER}, at::Atom
     end
 end
 
-function randf(::RWCMatrixModel, Σ::SparseMatrixCSC{SMatrix{3, 3, T, 9}, TI}) where {T<: Real, TI<:Int}
+function randf(::RWCMatrixModel, Σ::SparseMatrixCSC{SMatrix{3,3,T,9},TI}) where {T<:Real,TI<:Int}
     _, J, _ = findnz(Σ)
     ju = unique(J)
-    R = sparsevec(ju,randn(SVector{3,T},length(ju))) 
+    R = sparsevec(ju, randn(SVector{3,T}, length(ju)))
     return Σ * R
 end
 
-function randf(::RWCMatrixModel, Σ::SparseMatrixCSC{SVector{3, T}, TI}) where {T<: Real, TI<:Int}
+function randf(::RWCMatrixModel, Σ::SparseMatrixCSC{SVector{3,T},TI}) where {T<:Real,TI<:Int}
     _, J, _ = findnz(Σ)
     ju = unique(J)
-    R = sparsevec(ju,randn(length(ju))) 
+    R = sparsevec(ju, randn(length(ju)))
     return Σ * R
 end
 
 function ACEfrictionCore.write_dict(M::RWCMatrixModel{O3S,CUTOFF,EVALCENTER}) where {O3S,CUTOFF,EVALCENTER}
     return Dict("__id__" => "ACEfriction_ACMatrixModel",
-            "onsite" => ACEfrictionCore.write_dict(M.onsite),
-            #Dict(zz=>write_dict(val) for (zz,val) in M.onsite),
-            "offsite"  => ACEfrictionCore.write_dict(M.offsite),
-            # => Dict(zz=>write_dict(val) for (zz,val) in M.offsite),
-            "id" => string(M.id),
-            "O3S" => write_dict(O3S),
-            "CUTOFF" => write_dict(CUTOFF),
-            "EVALCENTER" => write_dict(EVALCENTER()))         
+        "onsite" => ACEfrictionCore.write_dict(M.onsite),
+        #Dict(zz=>write_dict(val) for (zz,val) in M.onsite),
+        "offsite" => ACEfrictionCore.write_dict(M.offsite),
+        # => Dict(zz=>write_dict(val) for (zz,val) in M.offsite),
+        "id" => string(M.id),
+        "O3S" => write_dict(O3S),
+        "CUTOFF" => write_dict(CUTOFF),
+        "EVALCENTER" => write_dict(EVALCENTER()))
 end
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_ACMatrixModel}, D::Dict)
-            onsite = ACEfrictionCore.read_dict(D["onsite"])
-            offsite = ACEfrictionCore.read_dict(D["offsite"])
-            #Dict(zz=>read_dict(val) for (zz,val) in D["onsite"])
-            #offsite = Dict(zz=>read_dict(val) for (zz,val) in D["offsite"])
-            id = Symbol(D["id"])
-            evalcenter = read_dict(D["EVALCENTER"])
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_ACMatrixModel}, D::AbstractDict)
+    onsite = ACEfrictionCore.read_dict(D["onsite"])
+    offsite = ACEfrictionCore.read_dict(D["offsite"])
+    #Dict(zz=>read_dict(val) for (zz,val) in D["onsite"])
+    #offsite = Dict(zz=>read_dict(val) for (zz,val) in D["offsite"])
+    id = Symbol(D["id"])
+    evalcenter = read_dict(D["EVALCENTER"])
     return RWCMatrixModel(onsite, offsite, id, evalcenter)
 end

--- a/src/matrixmodels/matrixmodels.jl
+++ b/src/matrixmodels/matrixmodels.jl
@@ -264,8 +264,8 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 
 
 # struct PWCoupledMatrixModel{O3S,TM,SPSYM,Z2S,CUTOFF}
-#     onsite::Dict{AtomicNumber,OnSiteModel{O3S,TM}}
-#     offsite::Dict{Tuple{AtomicNumber,AtomicNumber},OffSiteModel{O3S,TM,SPSYM,Z2S,CUTOFF}}
+#     onsite::AbstractDict{AtomicNumber,OnSiteModel{O3S,TM}}
+#     offsite::AbstractDict{Tuple{AtomicNumber,AtomicNumber},OffSiteModel{O3S,TM,SPSYM,Z2S,CUTOFF}}
 #     n_rep::Int
 #     inds::SiteInds
 #     id::Symbol
@@ -274,7 +274,7 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 
 
 
-# function OffSiteModels(models::Dict{Tuple{AtomicNumber,AtomicNumber}, TM}, env::CUTOFF, ::SPSYM, ::Z2S) where {TM, CUTOFF, Z2S, SPSYM} # this is a bit of hack. We directly provide the bond symmetry here as we can't infere it because it's built into the symmetric basis.
+# function OffSiteModels(models::AbstractDict{Tuple{AtomicNumber,AtomicNumber}, TM}, env::CUTOFF, ::SPSYM, ::Z2S) where {TM, CUTOFF, Z2S, SPSYM} # this is a bit of hack. We directly provide the bond symmetry here as we can't infere it because it's built into the symmetric basis.
 #     if SPSYM<:SpeciesCoupled
 #         @assert all(_msort(zz...) == zz for zz in keys(models))
 #     elseif SPSYM<:SpeciesUnCoupled
@@ -323,11 +323,11 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 # end
 
 
-# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM}, rcut::T, spsym=SpeciesUnCoupled()) where {T<:Real,TM}
+# function OffSiteModels(models::AbstractDict{Tuple{AtomicNumber, AtomicNumber},TM}, rcut::T, spsym=SpeciesUnCoupled()) where {T<:Real,TM}
 #     return OffSiteModels(models,SphericalCutoff(rcut), NoZ2Sym(), spsym)
 # end
 
-# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM},
+# function OffSiteModels(models::AbstractDict{Tuple{AtomicNumber, AtomicNumber},TM},
 #     rcutbond::T, rcutenv::T, zcutenv::T, z2sym=NoZ2Sym(), spsym=SpeciesUnCoupled()) where {T<:Real,TM}
 #     return OffSiteModels(models, EllipsoidCutoff(rcutbond, rcutenv, zcutenv), z2sym, spsym)
 # end
@@ -346,12 +346,12 @@ ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) =
 #         sqrt((offsite.env.rcutbond*.5)^2+ offsite.env.rcutenv^2)),
 #                 (r, z, i, j) -> env_filter(r, z), site_filter )
 struct SiteInds
-    onsite::Dict{AtomicNumber,UnitRange{Int}}
-    offsite::Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}
+    onsite::AbstractDict{AtomicNumber,UnitRange{Int}}
+    offsite::AbstractDict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}
 end
-SiteInds(onsite::Dict{AtomicNumber,UnitRange{Int}}) = SiteInds(onsite, Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}())
-SiteInds(offsite::Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}) = SiteInds(Dict{AtomicNumber,UnitRange{Int}}(), offsite)
-# function SiteInds(onsite::Dict{AtomicNumber, UnitRange{Int}}, offsite::Dict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}, speciescoupling::SPSYM )
+SiteInds(onsite::AbstractDict{AtomicNumber,UnitRange{Int}}) = SiteInds(onsite, AbstractDict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}())
+SiteInds(offsite::AbstractDict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}) = SiteInds(AbstractDict{AtomicNumber,UnitRange{Int}}(), offsite)
+# function SiteInds(onsite::AbstractDict{AtomicNumber, UnitRange{Int}}, offsite::AbstractDict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}, speciescoupling::SPSYM )
 #     _assert_offsite_keys(offsite,speciescoupling)
 #     new{SPSYM}(onsite, offsite)
 # end
@@ -553,11 +553,11 @@ get_range(m::MatrixModel, args...) = get_range(m.inds, args...)
 get_interaction(m::MatrixModel, args...) = get_interaction(m.inds, args...)
 
 
-# function _get_basisinds(onsitemodels::Dict{AtomicNumber, TM1},offsitemodels::Dict{Tuple{AtomicNumber, AtomicNumber}, TM2}) where {TM1, TM2}
+# function _get_basisinds(onsitemodels::AbstractDict{AtomicNumber, TM1},offsitemodels::AbstractDict{Tuple{AtomicNumber, AtomicNumber}, TM2}) where {TM1, TM2}
 #     return SiteInds(_get_basisinds(onsitemodels), _get_basisinds(offsitemodels))
 # end
 
-function _get_basisinds(models::Dict{Z,TM}) where {Z,TM}
+function _get_basisinds(models::AbstractDict{Z,TM}) where {Z,TM}
     inds = Dict{Z,UnitRange{Int}}()
     i0 = 1
     for (zz, mo) in models

--- a/src/matrixmodels/matrixmodels.jl
+++ b/src/matrixmodels/matrixmodels.jl
@@ -1,7 +1,7 @@
 module MatrixModels
 
 export MatrixModel, RWCMatrixModel, OnsiteOnlyMatrixModel, PWCMatrixModel
-export SiteModel, OnSiteModel, OffSiteModel,  OnSiteModels, OffSiteModels, SiteInds
+export SiteModel, OnSiteModel, OffSiteModel, OnSiteModels, OffSiteModels, SiteInds
 export onsite_linbasis, offsite_linbasis, env_cutoff, basis_size
 export O3Symmetry, Invariant, VectorEquivariant, MatrixEquivariant
 export Odd, Even, NoZ2Sym
@@ -28,7 +28,7 @@ import ACEfrictionCore: nparams, params, set_params!
 import ACEfrictionCore: write_dict, read_dict
 import ACEfrictionCore.ACEbonds: env_cutoff
 
-using ACEfrictionCore.ACEbonds.BondCutoffs 
+using ACEfrictionCore.ACEbonds.BondCutoffs
 using ACEfrictionCore.ACEbonds.BondCutoffs: AbstractBondCutoff
 
 using ACEfriction.AtomCutoffs: SphericalCutoff
@@ -43,35 +43,35 @@ ACEfrictionCore.write_dict(v::SVector{N,T}) where {N,T} = v
 ACEfrictionCore.read_dict(v::SVector{N,T}) where {N,T} = v
 
 #ACEfrictionCore.scaling(m::SiteModel,p::Int) = ACEfrictionCore.scaling(m.model.basis,p)
-abstract type O3Symmetry end 
+abstract type O3Symmetry end
 struct Invariant <: O3Symmetry end
 struct VectorEquivariant <: O3Symmetry end
 struct MatrixEquivariant <: O3Symmetry end
 
-abstract type Z2Symmetry end 
+abstract type Z2Symmetry end
 
 struct Odd <: Z2Symmetry end
 struct Even <: Z2Symmetry end
 struct NoZ2Sym <: Z2Symmetry end
 
 function ACEfrictionCore.write_dict(z2s::Z2S) where {Z2S<:Z2Symmetry}
-    return Dict("__id__" => string("ACEfriction_Z2Symmetry"), "z2s"=>typeof(z2s)) 
+    return Dict("__id__" => string("ACEfriction_Z2Symmetry"), "z2s" => typeof(z2s))
 end
 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_Z2Symmetry}, D::Dict) 
-    z2s = getfield(ACEfriction.MatrixModels, Symbol(split(D["z2s"], ".")[end])) # This was exporting it's full type, whereas we just need the last node. 
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_Z2Symmetry}, D::AbstractDict)
+    z2s = getfield(ACEfriction.MatrixModels, Symbol(split(D["z2s"], ".")[end])) # This was exporting it's full type, whereas we just need the last node.
     return z2s()
 end
-abstract type SpeciesCoupling end 
+abstract type SpeciesCoupling end
 
 struct SpeciesCoupled <: SpeciesCoupling end
 struct SpeciesUnCoupled <: SpeciesCoupling end
 
 function ACEfrictionCore.write_dict(sc::SC) where {SC<:SpeciesCoupling}
-    return Dict("__id__" => string("ACEfriction_SpeciesCoupling"), "sc"=>typeof(sc)) 
+    return Dict("__id__" => string("ACEfriction_SpeciesCoupling"), "sc" => typeof(sc))
 end
 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_SpeciesCoupling}, D::Dict) 
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_SpeciesCoupling}, D::AbstractDict)
     sc = getfield(ACEfriction.MatrixModels, Symbol(split(D["sc"], ".")[end]))
     return sc()
 end
@@ -82,34 +82,37 @@ struct NeighborCentered <: EvaluationCenter end
 struct AtomCentered <: EvaluationCenter end
 
 function ACEfrictionCore.write_dict(evalcenter::EVALCENTER) where {EVALCENTER<:EvaluationCenter}
-    return Dict("__id__" => string("ACEfriction_EvaluationMode"), "evalcenter"=>typeof(evalcenter)) 
+    return Dict("__id__" => string("ACEfriction_EvaluationMode"), "evalcenter" => typeof(evalcenter))
 end
-  
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_EvaluationMode}, D::Dict) 
+
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_EvaluationMode}, D::AbstractDict)
     evalcenter = getfield(ACEfriction.MatrixModels, Symbol(split(D["evalcenter"], ".")[end]))
     return evalcenter()
 end
 
-_mreduce(z1,z2, ::SpeciesUnCoupled) = (z1,z2)
-_mreduce(z1,z2, ::SpeciesCoupled) = _msort(z1,z2)
-_mreduce(z1,z2, ::Type{SpeciesUnCoupled}) = (z1,z2)
-_mreduce(z1,z2, ::Type{SpeciesCoupled}) = _msort(z1,z2)
+_mreduce(z1, z2, ::SpeciesUnCoupled) = (z1, z2)
+_mreduce(z1, z2, ::SpeciesCoupled) = _msort(z1, z2)
+_mreduce(z1, z2, ::Type{SpeciesUnCoupled}) = (z1, z2)
+_mreduce(z1, z2, ::Type{SpeciesCoupled}) = _msort(z1, z2)
 
 function _assert_consistency(mkeys, ::SpeciesUnCoupled)
-    return @assert all([((z2,z1) in mkeys && (z1,z2) in mkeys) for (z1,z2) in mkeys])
+    return @assert all([((z2, z1) in mkeys && (z1, z2) in mkeys) for (z1, z2) in mkeys])
 end
 
 function _assert_consistency(mkeys, ::SpeciesCoupled)
-    return @assert all([ begin (z1s,z2s) = _msort(z1,z2);
-                                ((z1s,z2s) in mkeys && ((z1s==z2s) || !((z2s,z1s) in mkeys)))
-                         end for (z1,z2) in mkeys])
+    return @assert all([
+        begin
+            (z1s, z2s) = _msort(z1, z2)
+            ((z1s, z2s) in mkeys && ((z1s == z2s) || !((z2s, z1s) in mkeys)))
+        end for (z1, z2) in mkeys
+    ])
 end
 
 function _assert_offsite_keys(offsite_dict, ::SpeciesCoupled)
-    return @assert all([(z2,z1)==_msort(z1,z2) for (z1,z2) in keys(offsite_dict)])
+    return @assert all([(z2, z1) == _msort(z1, z2) for (z1, z2) in keys(offsite_dict)])
 end
 function _assert_offsite_keys(offsite_dict, ::SpeciesUnCoupled)
-    return @assert all([(z2,z1) in keys(offsite_dict)  for (z1,z2) in keys(offsite_dict)])
+    return @assert all([(z2, z1) in keys(offsite_dict) for (z1, z2) in keys(offsite_dict)])
 end
 
 _o3symmetry(::ACEfrictionCore.SymmetricBasis{PIB,<:ACEfrictionCore.Invariant}) where {PIB} = Invariant
@@ -117,27 +120,27 @@ _o3symmetry(::ACEfrictionCore.SymmetricBasis{PIB,<:ACEfrictionCore.EuclideanVect
 _o3symmetry(::ACEfrictionCore.SymmetricBasis{PIB,<:ACEfrictionCore.EuclideanMatrix}) where {PIB} = MatrixEquivariant
 _o3symmetry(m::ACEfrictionCore.LinearACEModel) = _o3symmetry(m.basis)
 
-_n_rep(::ACEfrictionCore.LinearACEModel{TB, SVector{N,T}, TEV}) where {TB,N,T,TEV} = N
-_T(::ACEfrictionCore.LinearACEModel{TB, SVector{N,T}, TEV}) where {TB,N,T,TEV} = T
+_n_rep(::ACEfrictionCore.LinearACEModel{TB,SVector{N,T},TEV}) where {TB,N,T,TEV} = N
+_T(::ACEfrictionCore.LinearACEModel{TB,SVector{N,T},TEV}) where {TB,N,T,TEV} = T
 
 
-_msort(z1,z2) = (z1<=z2 ? (z1,z2) : (z2,z1))
+_msort(z1, z2) = (z1 <= z2 ? (z1, z2) : (z2, z1))
 # TODO: it may be better to base sorting on Atomic numbers instead of chemical_symbols
-_msort(z1::AtomicNumber,z2::AtomicNumber) = map(AtomicNumber,_msort(chemical_symbol(z1),chemical_symbol(z2)))
+_msort(z1::AtomicNumber, z2::AtomicNumber) = map(AtomicNumber, _msort(chemical_symbol(z1), chemical_symbol(z2)))
 
 NamedCollection = Union{AbstractDict,NamedTuple}
 
-function _o3symmetry(models::NamedCollection) 
+function _o3symmetry(models::NamedCollection)
     if isempty(models)
         return O3Symmetry
     else
-        O3S = eltype([_o3symmetry(mo.linmodel.basis)()  for mo in values(models)])
-        @assert ( O3S <: O3Symmetry && O3S != O3Symmetry) "Symmetries of model bases inconsistent. Symmetries must be of same type."
-        return O3S 
+        O3S = eltype([_o3symmetry(mo.linmodel.basis)() for mo in values(models)])
+        @assert (O3S <: O3Symmetry && O3S != O3Symmetry) "Symmetries of model bases inconsistent. Symmetries must be of same type."
+        return O3S
     end
 end
 
-function _o3symmetry(onsitemodels::NamedCollection, offsitemodels::NamedCollection) 
+function _o3symmetry(onsitemodels::NamedCollection, offsitemodels::NamedCollection)
     S1, S2 = _o3symmetry(onsitemodels), _o3symmetry(offsitemodels)
     @assert S1 <: S2 || S2 <: S1 "Symmetries of onsite and offsite models are inconsistent. These models must have symmetries of same type or one of the model dictionaries must be empty."
     return (S1 <: S2 ? S1 : S2)
@@ -145,12 +148,12 @@ end
 
 struct BondBasis{TM,Z2SYM}
     linbasis::TM
-    BondBasis(linbasis::TM,::Z2SYM) where {TM, Z2SYM<:Z2Symmetry}= new{TM,Z2SYM}(linbasis)
+    BondBasis(linbasis::TM, ::Z2SYM) where {TM,Z2SYM<:Z2Symmetry} = new{TM,Z2SYM}(linbasis)
 end
 
 Base.length(bb::BondBasis) = length(bb.linbasis)
 abstract type SiteModel end
-# Todo: allow for easy exclusion of onsite and offsite models 
+# Todo: allow for easy exclusion of onsite and offsite models
 _n_rep(model::SiteModel) = _n_rep(model.linmodel)
 struct OnSiteModel{O3S,TM} <: SiteModel
     linmodel::TM
@@ -161,65 +164,65 @@ struct OnSiteModel{O3S,TM} <: SiteModel
         return new{_o3symmetry(linmodel),typeof(linmodel)}(linmodel, cutoff)
     end
 end
-function OnSiteModel(linbasis::TM, cutoff::SphericalCutoff, n_rep::Ti) where {TM, Ti<:Int}
-    return OnSiteModel(linbasis, cutoff, rand(SVector{n_rep,Float64},length(linbasis)))
+function OnSiteModel(linbasis::TM, cutoff::SphericalCutoff, n_rep::Ti) where {TM,Ti<:Int}
+    return OnSiteModel(linbasis, cutoff, rand(SVector{n_rep,Float64}, length(linbasis)))
 end
-OnSiteModel(linbasis::TM,r_cut::T, n_rep::IT) where {TM,T<:Real,IT<:Int} = OnSiteModel(linbasis,SphericalCutoff(r_cut),n_rep)
+OnSiteModel(linbasis::TM, r_cut::T, n_rep::IT) where {TM,T<:Real,IT<:Int} = OnSiteModel(linbasis, SphericalCutoff(r_cut), n_rep)
 
 function ACEfrictionCore.write_dict(m::OnSiteModel{O3S,TM}) where {O3S,TM}
     T = _T(m.linmodel)
     c_vec = reinterpret(Vector{T}, m.linmodel.c)
     n_rep = _n_rep(m.linmodel)
     return Dict("__id__" => "ACEfriction_OnSiteModel",
-          "linbasis" => ACEfrictionCore.write_dict(m.linmodel.basis),
-          "c_vec" => ACEfrictionCore.write_dict(c_vec),
-          "n_rep" => n_rep,
-          "T" => ACEfrictionCore.write_dict(T),
-          "cutoff" => ACEfrictionCore.write_dict(m.cutoff)
-          )         
+        "linbasis" => ACEfrictionCore.write_dict(m.linmodel.basis),
+        "c_vec" => ACEfrictionCore.write_dict(c_vec),
+        "n_rep" => n_rep,
+        "T" => ACEfrictionCore.write_dict(T),
+        "cutoff" => ACEfrictionCore.write_dict(m.cutoff)
+    )
 end
 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_OnSiteModel}, D::Dict) 
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_OnSiteModel}, D::AbstractDict)
     linbasis = ACEfrictionCore.read_dict(D["linbasis"])
-    c_vec = ACEfrictionCore.read_dict(D["c_vec"]) 
-    n_rep = D["n_rep"]  
+    c_vec = ACEfrictionCore.read_dict(D["c_vec"])
+    n_rep = D["n_rep"]
     T = ACEfrictionCore.read_dict(D["T"])
     cutoff = ACEfrictionCore.read_dict(D["cutoff"])
-    return OnSiteModel(linbasis, cutoff, reinterpret(Vector{SVector{n_rep, T}}, c_vec))
+    return OnSiteModel(linbasis, cutoff, reinterpret(Vector{SVector{n_rep,T}}, c_vec))
 end
 struct OffSiteModel{O3S,Z2S,CUTOFF,TM} <: SiteModel # where {O3S<:O3Symmetry, CUTOFF<:AbstractCutoff, Z2S<:Z2Symmetry, SPSYM<:SpeciesCoupling}
     linmodel::TM
     cutoff::CUTOFF
-    function OffSiteModel(bb::BondBasis{TM,Z2S},  cutoff::CUTOFF, c::Vector{SVector{N,T}}) where  {TM, CUTOFF<:AbstractCutoff, Z2S<:Z2Symmetry, N, T<:Real}
+    function OffSiteModel(bb::BondBasis{TM,Z2S}, cutoff::CUTOFF, c::Vector{SVector{N,T}}) where {TM,CUTOFF<:AbstractCutoff,Z2S<:Z2Symmetry,N,T<:Real}
         @assert length(bb.linbasis) == length(c)
-        linmodel = ACEfrictionCore.LinearACEModel(bb.linbasis,c)
+        linmodel = ACEfrictionCore.LinearACEModel(bb.linbasis, c)
         return new{_o3symmetry(linmodel),Z2S,CUTOFF,typeof(linmodel)}(linmodel, cutoff)
     end
 end
 
-function OffSiteModel(bb::BondBasis{TM,Z2S},  cutoff::CUTOFF, n_rep::T) where { T<:Int, TM, CUTOFF<:AbstractCutoff, Z2S<:Z2Symmetry}
-    return OffSiteModel(bb,  cutoff, rand(SVector{n_rep,Float64},length(bb.linbasis)))
+function OffSiteModel(bb::BondBasis{TM,Z2S}, cutoff::CUTOFF, n_rep::T) where {T<:Int,TM,CUTOFF<:AbstractCutoff,Z2S<:Z2Symmetry}
+    return OffSiteModel(bb, cutoff, rand(SVector{n_rep,Float64}, length(bb.linbasis)))
 end
 
-OffSiteModel(bb::BondBasis{TM,Z2S},r_cut::T, n_rep::IT) where {TM,Z2S,T<:Real,IT<:Int} = OffSiteModel(bb, SphericalCutoff(r_cut), n_rep)
-OffSiteModel(bb::BondBasis{TM,Z2S}, rcutbond::T, rcutenv::T, zcutenv::T, n_rep::IT) where {TM,Z2S,T<:Real,IT<:Int} = OffSiteModel(bb, EllipsoidCutoff(rcutbond,rcutenv,zcutenv), n_rep)
+OffSiteModel(bb::BondBasis{TM,Z2S}, r_cut::T, n_rep::IT) where {TM,Z2S,T<:Real,IT<:Int} = OffSiteModel(bb, SphericalCutoff(r_cut), n_rep)
+OffSiteModel(bb::BondBasis{TM,Z2S}, rcutbond::T, rcutenv::T, zcutenv::T, n_rep::IT) where {TM,Z2S,T<:Real,IT<:Int} = OffSiteModel(bb, EllipsoidCutoff(rcutbond, rcutenv, zcutenv), n_rep)
 
 function ACEfrictionCore.write_dict(m::OffSiteModel{O3S,Z2S,CUTOFF,TM}) where {O3S,TM,Z2S,CUTOFF}
     return Dict("__id__" => "ACEfriction_OffSiteModel",
         "linbasis" => write_dict(m.linmodel.basis),
-          "c" => write_dict(reinterpret(Vector{Float64},params(m.linmodel))),
-          "n_rep"=>_n_rep(m.linmodel),
-          "cutoff" => write_dict(m.cutoff),
-          "Z2S" => write_dict(Z2S()))         
+        "c" => write_dict(reinterpret(Vector{Float64}, params(m.linmodel))),
+        "n_rep" => _n_rep(m.linmodel),
+        "cutoff" => write_dict(m.cutoff),
+        "Z2S" => write_dict(Z2S()))
 end
 
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_OffSiteModel}, D::Dict) 
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_OffSiteModel}, D::AbstractDict)
     linbasis = ACEfrictionCore.read_dict(D["linbasis"])
     n_rep = D["n_rep"]
-    c = reinterpret(Vector{SVector{n_rep,Float64}}, ACEfrictionCore.read_dict(D["c"]))   
+    c = reinterpret(Vector{SVector{n_rep,Float64}}, ACEfrictionCore.read_dict(D["c"]))
     cutoff = ACEfrictionCore.read_dict(D["cutoff"])
     Z2S = ACEfrictionCore.read_dict(D["Z2S"])
-    bondbais = BondBasis(linbasis,Z2S)
+    bondbais = BondBasis(linbasis, Z2S)
     return OffSiteModel(bondbais, cutoff, c)
 end
 
@@ -228,24 +231,24 @@ const OnSiteModels{O3S} = Dict{AtomicNumber,<:OnSiteModel{O3S}}
 #linmodel_size(models::OnSiteModels) = sum(length(mo.linmodel.basis) for mo in values(models))
 function ACEfrictionCore.write_dict(onsite::OnSiteModels)
     return Dict("__id__" => "ACEfriction_onsitemodels",
-                "zval" => Dict(string(chemical_symbol(z))=>ACEfrictionCore.write_dict(val) for (z,val) in onsite)
-                )
+        "zval" => Dict(string(chemical_symbol(z)) => ACEfrictionCore.write_dict(val) for (z, val) in onsite)
+    )
 end
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_onsitemodels}, D::Dict) 
-    return Dict(AtomicNumber(Symbol(z)) => ACEfrictionCore.read_dict(val) for (z,val) in D["zval"])  
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_onsitemodels}, D::AbstractDict)
+    return Dict(AtomicNumber(Symbol(z)) => ACEfrictionCore.read_dict(val) for (z, val) in D["zval"])
 end
 
-const OffSiteModels{O3S,Z2S,CUTOFF} = Dict{Tuple{AtomicNumber, AtomicNumber},<:OffSiteModel{O3S,Z2S,CUTOFF}}
+const OffSiteModels{O3S,Z2S,CUTOFF} = Dict{Tuple{AtomicNumber,AtomicNumber},<:OffSiteModel{O3S,Z2S,CUTOFF}}
 #linmodel_size(models::OffSiteModels) = sum(length(mo.linmodel.basis) for mo in values(models))
 function ACEfrictionCore.write_dict(offsite::OffSiteModels)
     return Dict("__id__" => "ACEfriction_offsitemodels",
-                "vals" => Dict(i=>ACEfrictionCore.write_dict(val) for (i,val) in enumerate(values(offsite))),
-                "z1" => Dict(i=>string(chemical_symbol(zz[1])) for (i,zz) in enumerate(keys(offsite))),
-                "z2" => Dict(i=>string(chemical_symbol(zz[2])) for (i,zz) in enumerate(keys(offsite)))
+        "vals" => Dict(i => ACEfrictionCore.write_dict(val) for (i, val) in enumerate(values(offsite))),
+        "z1" => Dict(i => string(chemical_symbol(zz[1])) for (i, zz) in enumerate(keys(offsite))),
+        "z2" => Dict(i => string(chemical_symbol(zz[2])) for (i, zz) in enumerate(keys(offsite)))
     )
 end
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_offsitemodels}, D::Dict) 
-    return Dict( (AtomicNumber(Symbol(z1)),AtomicNumber(Symbol(z2))) => ACEfrictionCore.read_dict(val)   for (z1,z2,val) in zip(values(D["z1"]),values(D["z2"]),values(D["vals"])))  
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_offsitemodels}, D::AbstractDict)
+    return Dict((AtomicNumber(Symbol(z1)), AtomicNumber(Symbol(z2))) => ACEfrictionCore.read_dict(val) for (z1, z2, val) in zip(values(D["z1"]), values(D["z2"]), values(D["vals"])))
 end
 const SiteModels = Union{OnSiteModels,OffSiteModels}
 
@@ -260,7 +263,7 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 
 
 
-# struct PWCoupledMatrixModel{O3S,TM,SPSYM,Z2S,CUTOFF} 
+# struct PWCoupledMatrixModel{O3S,TM,SPSYM,Z2S,CUTOFF}
 #     onsite::Dict{AtomicNumber,OnSiteModel{O3S,TM}}
 #     offsite::Dict{Tuple{AtomicNumber,AtomicNumber},OffSiteModel{O3S,TM,SPSYM,Z2S,CUTOFF}}
 #     n_rep::Int
@@ -271,26 +274,26 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 
 
 
-    # function OffSiteModels(models::Dict{Tuple{AtomicNumber,AtomicNumber}, TM}, env::CUTOFF, ::SPSYM, ::Z2S) where {TM, CUTOFF, Z2S, SPSYM} # this is a bit of hack. We directly provide the bond symmetry here as we can't infere it because it's built into the symmetric basis.
-    #     if SPSYM<:SpeciesCoupled
-    #         @assert all(_msort(zz...) == zz for zz in keys(models))
-    #     elseif SPSYM<:SpeciesUnCoupled
-    #         @assert all((z2,z1) in keys(models) for (z1,z2) in keys(models))
-    #     end
-    #     return new{_o3symmetry(models),SPSYM,Z2S,CUTOFF,TM}(models, env) 
-    # end
+# function OffSiteModels(models::Dict{Tuple{AtomicNumber,AtomicNumber}, TM}, env::CUTOFF, ::SPSYM, ::Z2S) where {TM, CUTOFF, Z2S, SPSYM} # this is a bit of hack. We directly provide the bond symmetry here as we can't infere it because it's built into the symmetric basis.
+#     if SPSYM<:SpeciesCoupled
+#         @assert all(_msort(zz...) == zz for zz in keys(models))
+#     elseif SPSYM<:SpeciesUnCoupled
+#         @assert all((z2,z1) in keys(models) for (z1,z2) in keys(models))
+#     end
+#     return new{_o3symmetry(models),SPSYM,Z2S,CUTOFF,TM}(models, env)
+# end
 
 
 # function OffSiteBasis(species;
-#     z2symmetry = NoZ2Sym(), 
+#     z2symmetry = NoZ2Sym(),
 #     maxorder = 2,
 #     maxdeg = 5,
 #     r0_ratio=.4,
-#     rin_ratio=.04, 
-#     pcut=2, 
-#     pin=2, 
-#     trans= polytransform(2, r0_ratio), 
-#     isym=:mube, 
+#     rin_ratio=.04,
+#     pcut=2,
+#     pin=2,
+#     trans= polytransform(2, r0_ratio),
+#     isym=:mube,
 #     weight = Dict(:l => 1.0, :n => 1.0),
 #     p_sel = 2,
 #     bond_weight = 1.0,
@@ -298,56 +301,56 @@ env_cutoff(models::SiteModels) = maximum(env_cutoff(mo.cutoff) for mo in values(
 #     species_maxorder_dict = Dict{Any, Float64}(),
 #     species_weight_cat = Dict(c => 1.0 for c in species),
 #     )
-#     @time offsite = SymmetricEllipsoidBondBasis(property; 
-#                 r0 = r0_ratio, 
-#                 rin = rin_ratio, 
-#                 pcut = pcut, 
-#                 pin = pin, 
+#     @time offsite = SymmetricEllipsoidBondBasis(property;
+#                 r0 = r0_ratio,
+#                 rin = rin_ratio,
+#                 pcut = pcut,
+#                 pin = pin,
 #                 trans = trans, #warning: the polytransform acts on [0,1]
-#                 p = p_sel, 
-#                 weight = weight, 
+#                 p = p_sel,
+#                 weight = weight,
 #                 maxorder = maxorder,
 #                 default_maxdeg = maxdeg,
 #                 species_minorder_dict = species_minorder_dict,
 #                 species_maxorder_dict = species_maxorder_dict,
 #                 species_weight_cat = species_weight_cat,
 #                 bondsymmetry=_z2couplingToString(z2symmetry),
-#                 species=species, 
-#                 isym=isym, 
-#                 bond_weight = bond_weight,  
+#                 species=species,
+#                 isym=isym,
+#                 bond_weight = bond_weight,
 #     )
 #     return offsite
 # end
 
 
-# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM}, rcut::T, spsym=SpeciesUnCoupled()) where {T<:Real,TM} 
+# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM}, rcut::T, spsym=SpeciesUnCoupled()) where {T<:Real,TM}
 #     return OffSiteModels(models,SphericalCutoff(rcut), NoZ2Sym(), spsym)
 # end
 
-# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM}, 
+# function OffSiteModels(models::Dict{Tuple{AtomicNumber, AtomicNumber},TM},
 #     rcutbond::T, rcutenv::T, zcutenv::T, z2sym=NoZ2Sym(), spsym=SpeciesUnCoupled()) where {T<:Real,TM}
 #     return OffSiteModels(models, EllipsoidCutoff(rcutbond, rcutenv, zcutenv), z2sym, spsym)
 # end
 
 
-ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds(at, Dict(zz=> mo.cutoff for (zz,mo) in offsite), site_filter) 
-#ACEfrictionCore.ACEbonds.bonds(at::Atoms, curoff::EllipsoidCutoff, site_filter) = ACEfrictionCore.ACEbonds.bonds(at, cutoff, site_filter) 
+ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds(at, Dict(zz => mo.cutoff for (zz, mo) in offsite), site_filter)
+#ACEfrictionCore.ACEbonds.bonds(at::Atoms, curoff::EllipsoidCutoff, site_filter) = ACEfrictionCore.ACEbonds.bonds(at, cutoff, site_filter)
 
-# ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds( at, envoffsite.env.rcutbond, 
-#     max(offsite.env.rcutbond*.5 + offsite.env.zcutenv, 
+# ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds( at, envoffsite.env.rcutbond,
+#     max(offsite.env.rcutbond*.5 + offsite.env.zcutenv,
 #         sqrt((offsite.env.rcutbond*.5)^2+ offsite.env.rcutenv^2)),
 #                 (r, z, zzi, zzj) -> env_filter(r, z, offsite[_msort(zzi,zzj)].cutoff), site_filter )
 
-# ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds( at, offsite.env.rcutbond, 
-#     max(offsite.env.rcutbond*.5 + offsite.env.zcutenv, 
+# ACEfrictionCore.ACEbonds.bonds(at::Atoms, offsite::OffSiteModels, site_filter) = ACEfrictionCore.ACEbonds.bonds( at, offsite.env.rcutbond,
+#     max(offsite.env.rcutbond*.5 + offsite.env.zcutenv,
 #         sqrt((offsite.env.rcutbond*.5)^2+ offsite.env.rcutenv^2)),
 #                 (r, z, i, j) -> env_filter(r, z), site_filter )
 struct SiteInds
-    onsite::Dict{AtomicNumber, UnitRange{Int}}
-    offsite::Dict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}
+    onsite::Dict{AtomicNumber,UnitRange{Int}}
+    offsite::Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}
 end
-SiteInds(onsite::Dict{AtomicNumber, UnitRange{Int}}) = SiteInds(onsite, Dict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}())
-SiteInds(offsite::Dict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}) = SiteInds(Dict{AtomicNumber, UnitRange{Int}}(), offsite)
+SiteInds(onsite::Dict{AtomicNumber,UnitRange{Int}}) = SiteInds(onsite, Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}())
+SiteInds(offsite::Dict{Tuple{AtomicNumber,AtomicNumber},UnitRange{Int}}) = SiteInds(Dict{AtomicNumber,UnitRange{Int}}(), offsite)
 # function SiteInds(onsite::Dict{AtomicNumber, UnitRange{Int}}, offsite::Dict{Tuple{AtomicNumber, AtomicNumber}, UnitRange{Int}}, speciescoupling::SPSYM )
 #     _assert_offsite_keys(offsite,speciescoupling)
 #     new{SPSYM}(onsite, offsite)
@@ -358,14 +361,14 @@ function Base.length(inds::SiteInds)
 end
 
 function Base.length(inds::SiteInds, site::Symbol)
-    return  (isempty(getfield(inds, site)) ? 0 : sum(length(irange) for irange in values(getfield(inds, site))))
+    return (isempty(getfield(inds, site)) ? 0 : sum(length(irange) for irange in values(getfield(inds, site))))
 end
 
 function get_range(inds::SiteInds, z::AtomicNumber)
     return inds.onsite[z]
 end
 
-function get_range(inds::SiteInds, zz::Tuple{AtomicNumber, AtomicNumber})
+function get_range(inds::SiteInds, zz::Tuple{AtomicNumber,AtomicNumber})
     return inds.offsite[zz]
 end
 
@@ -384,20 +387,20 @@ abstract type MatrixModel{S} end
 
 _default_id(::Type{Invariant}) = :inv
 _default_id(::Type{VectorEquivariant}) = :cov
-_default_id(::Type{MatrixEquivariant}) = :equ 
+_default_id(::Type{MatrixEquivariant}) = :equ
 
-_block_type(::MatrixModel{Invariant},T=Float64) = SMatrix{3, 3, T, 9}
-_block_type(::MatrixModel{VectorEquivariant},T=Float64) =  SVector{3,T}
-_block_type(::MatrixModel{MatrixEquivariant},T=Float64) = SMatrix{3, 3, T, 9}
+_block_type(::MatrixModel{Invariant}, T=Float64) = SMatrix{3,3,T,9}
+_block_type(::MatrixModel{VectorEquivariant}, T=Float64) = SVector{3,T}
+_block_type(::MatrixModel{MatrixEquivariant}, T=Float64) = SMatrix{3,3,T,9}
 
-_val2block(::MatrixModel{Invariant}, val::T) where {T<:Number}= SMatrix{3,3,T,9}(Diagonal([val,val,val]))
+_val2block(::MatrixModel{Invariant}, val::T) where {T<:Number} = SMatrix{3,3,T,9}(Diagonal([val, val, val]))
 _val2block(::MatrixModel{VectorEquivariant}, val) = val
 _val2block(::MatrixModel{MatrixEquivariant}, val) = val
 
 _n_rep(M::MatrixModel) = M.n_rep
 
 evaluate(sm::OnSiteModel, Rs, Zs) = evaluate(sm.linmodel, env_transform(Rs, Zs, sm.cutoff))
-evaluate(sm::OffSiteModel, rrij, zi::AtomicNumber, zj::AtomicNumber, Rs, Zs) = evaluate(sm.linmodel, env_transform(rrij, zi, zj, Rs, Zs, sm.cutoff)) 
+evaluate(sm::OffSiteModel, rrij, zi::AtomicNumber, zj::AtomicNumber, Rs, Zs) = evaluate(sm.linmodel, env_transform(rrij, zi, zj, Rs, Zs, sm.cutoff))
 
 
 _z2couplingToString(::NoZ2Sym) = "noz2sym"
@@ -410,19 +413,19 @@ _cutoff(cutoff::EllipsoidCutoff) = cutoff.r_cut
 
 """
 `NoMolOnly`: selects all basis functions which model interactions between atoms of the molecule only. Use this filter if the molecule feels only
-friction if in contact to the substrat.   
+friction if in contact to the substrat.
 """
 struct NoMolOnly
-      isym::Symbol
-      categories
+    isym::Symbol
+    categories
 end
-  
-function (f::NoMolOnly)(bb) 
-      if isempty(bb)
-            return true
-      else
-            return !all([getproperty(b, f.isym) in f.categories for b in bb])
-      end
+
+function (f::NoMolOnly)(bb)
+    if isempty(bb)
+        return true
+    else
+        return !all([getproperty(b, f.isym) in f.categories for b in bb])
+    end
 end
 
 """
@@ -430,132 +433,132 @@ end
 
 """
 struct SubstratContactFilter
-      isym::Symbol
-      substrat_atoms # List or set of chemical symbols of substrats atoms 
+    isym::Symbol
+    substrat_atoms # List or set of chemical symbols of substrats atoms
 end
-  
-function (f::SubstratContactFilter)(bb) 
-      if isempty(bb)
-            return true
-      else
-            return sum([getproperty(b, f.isym) in f.substrat_atoms for b in bb]) > 0
-      end
+
+function (f::SubstratContactFilter)(bb)
+    if isempty(bb)
+        return true
+    else
+        return sum([getproperty(b, f.isym) in f.substrat_atoms for b in bb]) > 0
+    end
 end
 
 
-function offsite_linbasis(property,species;
-    z2symmetry = NoZ2Sym(), 
-    maxorder = 2,
-    maxdeg = 5,
-    r0_ratio=.4,
-    rin_ratio=.04, 
-    pcut=2, 
-    pin=2, 
-    trans= polytransform(2, r0_ratio), 
-    isym=:mube, 
-    weight = Dict(:l => 1.0, :n => 1.0),
-    p_sel = 2,
-    bond_weight = 1.0,
-    species_minorder_dict = Dict{Any, Float64}(),
-    species_maxorder_dict = Dict{Any, Float64}(),
-    species_weight_cat = Dict(c => 1.0 for c in species),
-    species_substrat = []
-    )
+function offsite_linbasis(property, species;
+    z2symmetry=NoZ2Sym(),
+    maxorder=2,
+    maxdeg=5,
+    r0_ratio=0.4,
+    rin_ratio=0.04,
+    pcut=2,
+    pin=2,
+    trans=polytransform(2, r0_ratio),
+    isym=:mube,
+    weight=Dict(:l => 1.0, :n => 1.0),
+    p_sel=2,
+    bond_weight=1.0,
+    species_minorder_dict=Dict{Any,Float64}(),
+    species_maxorder_dict=Dict{Any,Float64}(),
+    species_weight_cat=Dict(c => 1.0 for c in species),
+    species_substrat=[]
+)
     if isempty(species_substrat)
         filterfun = _ -> true
     else
         filterfun = SubstratContactFilter(:mube, species_substrat)
-    end 
+    end
 
     @info "Generate offsite basis"
-    @time offsite = SymmetricEllipsoidBondBasis2(property; 
-                r0 = r0_ratio, 
-                rin = rin_ratio, 
-                pcut = pcut, 
-                pin = pin, 
-                trans = trans, #warning: the polytransform acts on [0,1]
-                p = p_sel, 
-                weight = weight, 
-                maxorder = maxorder,
-                default_maxdeg = maxdeg,
-                species_minorder_dict = species_minorder_dict,
-                species_maxorder_dict = species_maxorder_dict,
-                species_weight_cat = species_weight_cat,
-                bondsymmetry=_z2couplingToString(z2symmetry),
-                species=species, 
-                isym=isym, 
-                bond_weight = bond_weight,
-                filterfun = filterfun
+    @time offsite = SymmetricEllipsoidBondBasis2(property;
+        r0=r0_ratio,
+        rin=rin_ratio,
+        pcut=pcut,
+        pin=pin,
+        trans=trans, #warning: the polytransform acts on [0,1]
+        p=p_sel,
+        weight=weight,
+        maxorder=maxorder,
+        default_maxdeg=maxdeg,
+        species_minorder_dict=species_minorder_dict,
+        species_maxorder_dict=species_maxorder_dict,
+        species_weight_cat=species_weight_cat,
+        bondsymmetry=_z2couplingToString(z2symmetry),
+        species=species,
+        isym=isym,
+        bond_weight=bond_weight,
+        filterfun=filterfun
     )
     @info "Size of offsite basis elements: $(length(offsite))"
-    return BondBasis(offsite,z2symmetry)
+    return BondBasis(offsite, z2symmetry)
 end
 
-function onsite_linbasis(property,species;
-    maxorder=2, maxdeg=5, r0_ratio=.4, rin_ratio=.04, pcut=2, pin=2,
-    trans= polytransform(2, r0_ratio), #warning: the polytransform acts on [0,1]
-    p_sel = 2, 
-    species_minorder_dict = Dict{Any, Float64}(),
-    species_maxorder_dict = Dict{Any, Float64}(),
-    weight = Dict(:l => 1.0, :n => 1.0), 
-    species_weight_cat = Dict(c => 1.0 for c in species),
-    species_substrat = []
-    )
+function onsite_linbasis(property, species;
+    maxorder=2, maxdeg=5, r0_ratio=0.4, rin_ratio=0.04, pcut=2, pin=2,
+    trans=polytransform(2, r0_ratio), #warning: the polytransform acts on [0,1]
+    p_sel=2,
+    species_minorder_dict=Dict{Any,Float64}(),
+    species_maxorder_dict=Dict{Any,Float64}(),
+    weight=Dict(:l => 1.0, :n => 1.0),
+    species_weight_cat=Dict(c => 1.0 for c in species),
+    species_substrat=[]
+)
     @info "Generate onsite basis"
-    Bsel = ACEfrictionCore.SparseBasis(; maxorder=maxorder, p = p_sel, default_maxdeg = maxdeg, weight=weight ) 
-    RnYlm = ACEfrictionCore.Utils.RnYlm_1pbasis(;  
-            r0 = r0_ratio,
-            rin = rin_ratio,
-            trans = trans, 
-            pcut = pcut,
-            pin = pin, 
-            Bsel = Bsel, 
-            rcut=1.0,
-            maxdeg= maxdeg * max(1,Int(ceil(1/minimum(values(species_weight_cat)))))
-        );
-    Zk = ACEfrictionCore.Categorical1pBasis(species; varsym = :mu, idxsym = :mu) #label = "Zk"
+    Bsel = ACEfrictionCore.SparseBasis(; maxorder=maxorder, p=p_sel, default_maxdeg=maxdeg, weight=weight)
+    RnYlm = ACEfrictionCore.Utils.RnYlm_1pbasis(;
+        r0=r0_ratio,
+        rin=rin_ratio,
+        trans=trans,
+        pcut=pcut,
+        pin=pin,
+        Bsel=Bsel,
+        rcut=1.0,
+        maxdeg=maxdeg * max(1, Int(ceil(1 / minimum(values(species_weight_cat)))))
+    )
+    Zk = ACEfrictionCore.Categorical1pBasis(species; varsym=:mu, idxsym=:mu) #label = "Zk"
     Bselcat = ACEfrictionCore.CategorySparseBasis(:mu, species;
-        maxorder = ACEfrictionCore.maxorder(Bsel), 
-        p = Bsel.p, 
-        weight = Bsel.weight, 
-        maxlevels = Bsel.maxlevels,
-        minorder_dict = species_minorder_dict,
-        maxorder_dict = species_maxorder_dict, 
-        weight_cat = species_weight_cat
+        maxorder=ACEfrictionCore.maxorder(Bsel),
+        p=Bsel.p,
+        weight=Bsel.weight,
+        maxlevels=Bsel.maxlevels,
+        minorder_dict=species_minorder_dict,
+        maxorder_dict=species_maxorder_dict,
+        weight_cat=species_weight_cat
     )
     if isempty(species_substrat)
         filter = _ -> true
     else
         filter = SubstratContactFilter(:mu, species_substrat)
     end
-    @time onsite = ACEfrictionCore.SymmetricBasis(property, RnYlm * Zk, Bselcat; filterfun=filter);
+    @time onsite = ACEfrictionCore.SymmetricBasis(property, RnYlm * Zk, Bselcat; filterfun=filter)
     @info "Size of onsite basis: $(length(onsite))"
     return onsite
 end
 
-function ACEfrictionCore.scaling(mb::MatrixModel, p::Int) 
-    scale = (onsite=ones(length(mb,:onsite)), offsite=ones(length(mb,:offsite)))
-    for site in [:onsite,:offsite]
-        site = getfield(mb,site)
+function ACEfrictionCore.scaling(mb::MatrixModel, p::Int)
+    scale = (onsite=ones(length(mb, :onsite)), offsite=ones(length(mb, :offsite)))
+    for site in [:onsite, :offsite]
+        site = getfield(mb, site)
         for (zz, mo) in site.models
-            scale[:onsite][get_range(mb,zz)] = ACEfrictionCore.scaling(mo.basis,p)
+            scale[:onsite][get_range(mb, zz)] = ACEfrictionCore.scaling(mo.basis, p)
         end
     end
     return scale
 end
 
-Base.length(m::MatrixModel,args...) = length(m.inds,args...)
+Base.length(m::MatrixModel, args...) = length(m.inds, args...)
 
-get_range(m::MatrixModel,args...) = get_range(m.inds,args...)
-get_interaction(m::MatrixModel,args...) = get_interaction(m.inds,args...)
+get_range(m::MatrixModel, args...) = get_range(m.inds, args...)
+get_interaction(m::MatrixModel, args...) = get_interaction(m.inds, args...)
 
 
 # function _get_basisinds(onsitemodels::Dict{AtomicNumber, TM1},offsitemodels::Dict{Tuple{AtomicNumber, AtomicNumber}, TM2}) where {TM1, TM2}
 #     return SiteInds(_get_basisinds(onsitemodels), _get_basisinds(offsitemodels))
 # end
 
-function _get_basisinds(models::Dict{Z, TM}) where {Z,TM}
-    inds = Dict{Z, UnitRange{Int}}()
+function _get_basisinds(models::Dict{Z,TM}) where {Z,TM}
+    inds = Dict{Z,UnitRange{Int}}()
     i0 = 1
     for (zz, mo) in models
         @assert typeof(mo.linmodel) <: ACEfrictionCore.LinearACEModel
@@ -568,33 +571,33 @@ end
 
 
 _get_model(calc::MatrixModel, zz::Tuple{AtomicNumber,AtomicNumber}) = calc.offsite[zz]
-_get_model(calc::MatrixModel, z::AtomicNumber) =  calc.onsite[z]
+_get_model(calc::MatrixModel, z::AtomicNumber) = calc.onsite[z]
 
 
 
 function ACEfrictionCore.params(mb::MatrixModel; format=:matrix, joinsites=true) # :vector, :matrix
     @assert format in [:native, :matrix]
-    if joinsites  
+    if joinsites
         return vcat(ACEfrictionCore.params(mb, :onsite; format=format), ACEfrictionCore.params(mb, :offsite; format=format))
-    else 
-        return (onsite=ACEfrictionCore.params(mb, :onsite;  format=format),
-                offsite=ACEfrictionCore.params(mb, :offsite; format=format))
+    else
+        return (onsite=ACEfrictionCore.params(mb, :onsite; format=format),
+            offsite=ACEfrictionCore.params(mb, :offsite; format=format))
     end
 end
 
 
 function ACEfrictionCore.params(mb::MatrixModel, site::Symbol; format=:matrix)
     θ = zeros(SVector{mb.n_rep,Float64}, nparams(mb, site))
-    for z in keys(getfield(mb,site))
+    for z in keys(getfield(mb, site))
         sm = _get_model(mb, z)
         inds = get_range(mb, z)
-        θ[inds] = params(sm.linmodel) 
+        θ[inds] = params(sm.linmodel)
     end
     return _transform(θ, Val(format), mb.n_rep)
 end
 
 function ACEfrictionCore.params(calc::MatrixModel, zzz::Union{AtomicNumber,Tuple{AtomicNumber,AtomicNumber}})
-    return params(_get_model(calc,zzz))
+    return params(_get_model(calc, zzz))
 end
 
 
@@ -607,7 +610,7 @@ function ACEfrictionCore.nparams(mb::MatrixModel, site::Symbol)
 end
 
 function ACEfrictionCore.nparams(calc::MatrixModel, zzz::Union{AtomicNumber,Tuple{AtomicNumber,AtomicNumber}}) # make zzz
-    return nparams(_get_model(calc,zzz))
+    return nparams(_get_model(calc, zzz))
 end
 
 # function ACE.set_params!(mb::MatrixModel, θ::Vector)
@@ -616,7 +619,7 @@ end
 # end
 
 function ACEfrictionCore.set_params!(mb::MatrixModel, θ)
-    θt = _split_sites(mb, θ) 
+    θt = _split_sites(mb, θ)
     ACEfrictionCore.set_params!(mb::MatrixModel, θt)
 end
 
@@ -624,18 +627,18 @@ function set_params!(mb::MatrixModel, site::Symbol, θ)
     θt = _rev_transform(θ, mb.n_rep)
     sitedict = getfield(mb, site)
     for z in keys(sitedict)
-        ACEfrictionCore.set_params!(_get_model(mb,z),θt[get_range(mb,z)]) 
+        ACEfrictionCore.set_params!(_get_model(mb, z), θt[get_range(mb, z)])
     end
 end
 
 set_params!(model::SiteModel, θt) = set_params!(model.linmodel, θt)
 
 function ACEfrictionCore.set_params!(calc::MatrixModel, zzz::Union{AtomicNumber,Tuple{AtomicNumber,AtomicNumber}}, θ)
-    return ACEfrictionCore.set_params!(_get_model(calc,zzz),θ)
+    return ACEfrictionCore.set_params!(_get_model(calc, zzz), θ)
 end
 
 function set_zero!(mb::MatrixModel)
-    for site in [:onsite,:offsite]
+    for site in [:onsite, :offsite]
         ACEfrictionCore.set_zero!(mb, site)
     end
 end
@@ -645,16 +648,16 @@ function set_zero!(mb::MatrixModel, site::Symbol)
     ACEfrictionCore.set_params!(mb, θ)
 end
 
-# Auxiliary functions to handle different formats of parameters (as NamedTuple vs one block & Matrix vs Vector{SVector{...}})  and basis (as NamedTuple vs one bloc 
-_join_sites(h1,h2) = vcat(h1,h2)
+# Auxiliary functions to handle different formats of parameters (as NamedTuple vs one block & Matrix vs Vector{SVector{...}})  and basis (as NamedTuple vs one bloc
+_join_sites(h1, h2) = vcat(h1, h2)
 
-function _split_sites(mb::MatrixModel, h::Vector) 
-    imax_onsite = length(mb,:onsite)
+function _split_sites(mb::MatrixModel, h::Vector)
+    imax_onsite = length(mb, :onsite)
     return (onsite=h[1:imax_onsite], offsite=h[(imax_onsite+1):end])
 end
-function _split_sites(mb::MatrixModel, H::Matrix) 
-    imax_onsite = length(mb,:onsite)
-    return (onsite=H[1:imax_onsite,:], offsite=H[(imax_onsite+1):end,:])
+function _split_sites(mb::MatrixModel, H::Matrix)
+    imax_onsite = length(mb, :onsite)
+    return (onsite=H[1:imax_onsite, :], offsite=H[(imax_onsite+1):end, :])
 end
 
 function _transform(θ, ::Val{:matrix}, n_rep)
@@ -668,38 +671,38 @@ function _rev_transform(θ, n_rep)
 end
 
 
-function matrix(M::MatrixModel, at::Atoms;  filter=(_,_)->true, T=Float64) 
+function matrix(M::MatrixModel, at::Atoms; filter=(_, _) -> true, T=Float64)
     A = allocate_matrix(M, at, T)
     matrix!(M, at, A, filter)
     return A
 end
 
-# TODO: most matrix and basis allocation and assembly methods use bad practice. They should be rewritten for efficiency purposes. 
-function allocate_matrix(M::MatrixModel, at::Atoms,  T=Float64) 
+# TODO: most matrix and basis allocation and assembly methods use bad practice. They should be rewritten for efficiency purposes.
+function allocate_matrix(M::MatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    A = [spzeros(_block_type(M,T),N,N) for _ = 1:M.n_rep]
+    A = [spzeros(_block_type(M, T), N, N) for _ = 1:M.n_rep]
     return A
 end
 
-function basis(M::MatrixModel, at::Atoms; join_sites=false, filter=(_,_)->true, T=Float64) 
+function basis(M::MatrixModel, at::Atoms; join_sites=false, filter=(_, _) -> true, T=Float64)
     B = allocate_B(M, at, T)
     basis!(B, M, at, filter)
-    return (join_sites ? _join_sites(B.onsite,B.offsite) : B)
+    return (join_sites ? _join_sites(B.onsite, B.offsite) : B)
 end
 
 
 function allocate_B(M::MatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    B_onsite = [Diagonal( zeros(_block_type(M,T),N)) for _ = 1:length(M.inds,:onsite)]
-    B_offsite = [spzeros(_block_type(M,T),N,N) for _ =  1:length(M.inds,:offsite)]
+    B_onsite = [Diagonal(zeros(_block_type(M, T), N)) for _ = 1:length(M.inds, :onsite)]
+    B_offsite = [spzeros(_block_type(M, T), N, N) for _ = 1:length(M.inds, :offsite)]
     return (onsite=B_onsite, offsite=B_offsite)
 end
 
-randf(M::MT, Σ_vec::Array{T,1}) where {MT<:MatrixModel, T} = sum(randf(M,Σ) for Σ in Σ_vec)
+randf(M::MT, Σ_vec::Array{T,1}) where {MT<:MatrixModel,T} = sum(randf(M, Σ) for Σ in Σ_vec)
 
 get_id(M::MatrixModel) = M.id
 
-# Atom-centered matrix models: 
+# Atom-centered matrix models:
 include("./acmatrixmodels.jl")
 # Pairwise Coupled matrix models:
 include("./pwcmatrixmodels.jl")

--- a/src/matrixmodels/onsiteonlymatrixmodels.jl
+++ b/src/matrixmodels/onsiteonlymatrixmodels.jl
@@ -5,45 +5,45 @@ struct OnsiteOnlyMatrixModel{O3S} <: MatrixModel{O3S}
     id::Symbol
     function OnsiteOnlyMatrixModel(onsite::OnSiteModels{O3S}, id::Symbol) where {O3S}
         @assert length(unique([_n_rep(mo) for mo in values(onsite)])) == 1
-        @assert length(unique([mo.cutoff for mo in values(onsite)])) == 1 
+        @assert length(unique([mo.cutoff for mo in values(onsite)])) == 1
         return new{O3S}(onsite, _n_rep(onsite), SiteInds(_get_basisinds(onsite)), id)
     end
 end
 
 function ACEfrictionCore.params(mb::OnsiteOnlyMatrixModel; format=:matrix, joinsites=true) # :vector, :matrix
     @assert format in [:native, :matrix]
-    if joinsites  
+    if joinsites
         return ACEfrictionCore.params(mb, :onsite; format=format)
-    else 
+    else
         θ_onsite = ACEfrictionCore.params(mb, :onsite; format=format)
         return (onsite=θ_onsite, offsite=eltype(θ_offsite)[],)
     end
 end
 
 function ACEfrictionCore.set_params!(mb::OnsiteOnlyMatrixModel, θ::NamedTuple)
-    ACEfrictionCore.set_params!(mb, :onsite,  θ.onsite)
+    ACEfrictionCore.set_params!(mb, :onsite, θ.onsite)
 end
 
-function allocate_matrix(M::OnsiteOnlyMatrixModel, at::Atoms,  T=Float64) 
+function allocate_matrix(M::OnsiteOnlyMatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    return [Diagonal(zeros(_block_type(M,T),N)) for _ = 1:M.n_rep]
+    return [Diagonal(zeros(_block_type(M, T), N)) for _ = 1:M.n_rep]
 end
 
-function matrix!(M::OnsiteOnlyMatrixModel{O3S}, at::Atoms, Σ, filter=(_,_)->true) where {O3S}
-    site_filter(i,at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
+function matrix!(M::OnsiteOnlyMatrixModel{O3S}, at::Atoms, Σ, filter=(_, _) -> true) where {O3S}
+    site_filter(i, at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
     for (i, neigs, Rs) in sites(at, env_cutoff(M.onsite))
         if site_filter(i, at) && length(neigs) > 0
             Zs = at.Z[neigs]
             sm = _get_model(M, at.Z[i])
             Σ_temp = evaluate(sm, Rs, Zs)
-            for r=1:M.n_rep
-                Σ[r][i,i] += _val2block(M, Σ_temp[r].val)
+            for r = 1:M.n_rep
+                Σ[r][i, i] += _val2block(M, Σ_temp[r].val)
             end
         end
     end
 end
 
-function basis(M::OnsiteOnlyMatrixModel, at::Atoms; join_sites=false, filter=(_,_)->true, T=Float64) 
+function basis(M::OnsiteOnlyMatrixModel, at::Atoms; join_sites=false, filter=(_, _) -> true, T=Float64)
     B = allocate_B(M, at, T)
     basis!(B, M, at, filter)
     return (join_sites ? B[1] : B)
@@ -51,12 +51,12 @@ end
 
 function allocate_B(M::OnsiteOnlyMatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    B_onsite = [Diagonal( zeros(_block_type(M,T),N)) for _ = 1:length(M.inds,:onsite)]
+    B_onsite = [Diagonal(zeros(_block_type(M, T), N)) for _ = 1:length(M.inds, :onsite)]
     return (onsite=B_onsite,)
 end
 
-function basis!(B, M::OnsiteOnlyMatrixModel, at::Atoms, filter=(_,_)->true)
-    site_filter(i,at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
+function basis!(B, M::OnsiteOnlyMatrixModel, at::Atoms, filter=(_, _) -> true)
+    site_filter(i, at) = (haskey(M.onsite, at.Z[i]) && filter(i, at))
     for (i, neigs, Rs) in sites(at, env_cutoff(M.onsite))
         if site_filter(i, at) && length(neigs) > 0
             # evaluate basis of onsite model
@@ -64,30 +64,30 @@ function basis!(B, M::OnsiteOnlyMatrixModel, at::Atoms, filter=(_,_)->true)
             sm = _get_model(M, at.Z[i])
             inds = get_range(M, at.Z[i])
             Bii = evaluate(sm.linmodel.basis, env_transform(Rs, Zs, sm.cutoff))
-            for (k,b) in zip(inds,Bii)
-                B.onsite[k][i,i] += _val2block(M, b.val)
+            for (k, b) in zip(inds, Bii)
+                B.onsite[k][i, i] += _val2block(M, b.val)
             end
         end
     end
 end
 
-function randf(::OnsiteOnlyMatrixModel, Σ::Diagonal{SMatrix{3, 3, T, 9}}) where {T<:Real}
-    return Σ * randn(SVector{3,T},size(Σ,2))
+function randf(::OnsiteOnlyMatrixModel, Σ::Diagonal{SMatrix{3,3,T,9}}) where {T<:Real}
+    return Σ * randn(SVector{3,T}, size(Σ, 2))
 end
 
-function randf(::OnsiteOnlyMatrixModel, Σ::Diagonal{SVector{3, T}}) where {T<:Real}
-    return Σ * randn(size(Σ,2))
+function randf(::OnsiteOnlyMatrixModel, Σ::Diagonal{SVector{3,T}}) where {T<:Real}
+    return Σ * randn(size(Σ, 2))
 end
 
-function ACEfrictionCore.write_dict(M::OnsiteOnlyMatrixModel) 
+function ACEfrictionCore.write_dict(M::OnsiteOnlyMatrixModel)
     return Dict("__id__" => "ACEfriction_OnsiteOnlyMatrixModel",
-            "onsite" => write_dict(M.onsite),
-            #Dict(zz=>write_dict(val) for (zz,val) in M.onsite),
-            "id" => string(M.id))         
+        "onsite" => write_dict(M.onsite),
+        #Dict(zz=>write_dict(val) for (zz,val) in M.onsite),
+        "id" => string(M.id))
 end
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_OnsiteOnlyMatrixModel}, D::Dict)
-            onsite = read_dict(D["onsite"])
-            #Dict(zz=>read_dict(val) for (zz,val) in D["onsite"])
-            id = Symbol(D["id"])
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_OnsiteOnlyMatrixModel}, D::AbstractDict)
+    onsite = read_dict(D["onsite"])
+    #Dict(zz=>read_dict(val) for (zz,val) in D["onsite"])
+    id = Symbol(D["id"])
     return OnsiteOnlyMatrixModel(onsite, id)
 end

--- a/src/matrixmodels/pwcmatrixmodels.jl
+++ b/src/matrixmodels/pwcmatrixmodels.jl
@@ -1,24 +1,24 @@
 struct PWCMatrixModel{O3S,CUTOFF,Z2S,SC} <: MatrixModel{O3S}
-    offsite::OffSiteModels{O3S,Z2S,CUTOFF} where {Z2S, CUTOFF}
+    offsite::OffSiteModels{O3S,Z2S,CUTOFF} where {Z2S,CUTOFF}
     n_rep::Int
     inds::SiteInds
     id::Symbol
-    function PWCMatrixModel(offsite::OffSiteModels{O3S,Z2S,CUTOFF}, id::Symbol,sc::SC) where {O3S,Z2S,CUTOFF,SC}
-        _assert_consistency(keys(offsite),sc)
+    function PWCMatrixModel(offsite::OffSiteModels{O3S,Z2S,CUTOFF}, id::Symbol, sc::SC) where {O3S,Z2S,CUTOFF,SC}
+        _assert_consistency(keys(offsite), sc)
         @assert length(unique([_n_rep(mo) for mo in values(offsite)])) == 1
-        @assert length(unique([mo.cutoff for mo in values(offsite)])) == 1 
+        @assert length(unique([mo.cutoff for mo in values(offsite)])) == 1
         return new{O3S,CUTOFF,Z2S,SC}(offsite, _n_rep(offsite), SiteInds(_get_basisinds(offsite)), id)
     end
 end
 
-_get_SC(::PWCMatrixModel{O3S,TM,Z2S,SC}) where {O3S, Z2S, TM, SC} = SC
+_get_SC(::PWCMatrixModel{O3S,TM,Z2S,SC}) where {O3S,Z2S,TM,SC} = SC
 
 
 function ACEfrictionCore.params(mb::PWCMatrixModel; format=:matrix, joinsites=true) # :vector, :matrix
     @assert format in [:native, :matrix]
-    if joinsites  
+    if joinsites
         return ACEfrictionCore.params(mb, :offsite; format=format)
-    else 
+    else
         θ_offsite = ACEfrictionCore.params(mb, :offsite; format=format)
         return (onsite=eltype(θ_offsite)[], offsite=θ_offsite,)
     end
@@ -28,27 +28,27 @@ function ACEfrictionCore.set_params!(mb::PWCMatrixModel, θ::NamedTuple)
     ACEfrictionCore.set_params!(mb, :offsite, θ.offsite)
 end
 
-function allocate_matrix(M::PWCMatrixModel, at::Atoms,  T=Float64) 
+function allocate_matrix(M::PWCMatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    A = [spzeros(_block_type(M,T),N,N) for _ = 1:M.n_rep]
+    A = [spzeros(_block_type(M, T), N, N) for _ = 1:M.n_rep]
     return A
 end
 
-function matrix!(M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, A, filter=(_,_)->true) where {O3S, Z2S, SC}
-    site_filter(i,at) = filter(i, at)
+function matrix!(M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, A, filter=(_, _) -> true) where {O3S,Z2S,SC}
+    site_filter(i, at) = filter(i, at)
     for (i, neigs, Rs) in sites(at, env_cutoff(M.offsite))
         if site_filter(i, at) && length(neigs) > 0
             Zs = at.Z[neigs]
             # evaluate offsite model
             for (j_loc, j) in enumerate(neigs) #rij, riι
                 if site_filter(j, at)
-                    (Zi, Zj) = _mreduce(at.Z[i],at.Z[j], SC)
-                    if haskey(M.offsite,(Zi,Zj))
-                        sm = M.offsite[(Zi,Zj)]
+                    (Zi, Zj) = _mreduce(at.Z[i], at.Z[j], SC)
+                    if haskey(M.offsite, (Zi, Zj))
+                        sm = M.offsite[(Zi, Zj)]
                         cfg = env_transform(j_loc, Rs, Zs, sm.cutoff)
                         Σ_temp = evaluate(sm.linmodel, cfg)
-                        for r=1:M.n_rep
-                            A[r][i,j] += _val2block(M, Σ_temp[r].val)
+                        for r = 1:M.n_rep
+                            A[r][i, j] += _val2block(M, Σ_temp[r].val)
                         end
                     end
                 end
@@ -57,25 +57,25 @@ function matrix!(M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, A, 
     end
 end
 
-function matrix!(M::PWCMatrixModel{O3S,<:EllipsoidCutoff,Z2S,SC}, at::Atoms, A, filter=(_,_)->true) where {O3S, Z2S, SC}
-    site_filter(i,at) = filter(i, at)
+function matrix!(M::PWCMatrixModel{O3S,<:EllipsoidCutoff,Z2S,SC}, at::Atoms, A, filter=(_, _) -> true) where {O3S,Z2S,SC}
+    site_filter(i, at) = filter(i, at)
     if !isempty(M.offsite)
-        for (i, j, rrij, Js, Rs, Zs) in bonds(at, Dict(zz=>cut for (zz,cut) in M.offsite), filter)
-            (Zi, Zj) = _mreduce(at.Z[i],at.Z[j], SC)
+        for (i, j, rrij, Js, Rs, Zs) in bonds(at, Dict(zz => cut for (zz, cut) in M.offsite), filter)
+            (Zi, Zj) = _mreduce(at.Z[i], at.Z[j], SC)
             # @show (at.Z[i],at.Z[j]), (Zi, Zj)
             sm = M.offsite[(Zi, Zj)]
             # transform the ellipse to a sphere
             cfg = env_transform(rrij, Zi, Zj, Rs, Zs, sm.cutoff)
             A_temp = evaluate(sm.linmodel, cfg)
-            for r=1:M.n_rep
-                A[r][i,j] = _val2block(M, A_temp[r].val)
+            for r = 1:M.n_rep
+                A[r][i, j] = _val2block(M, A_temp[r].val)
             end
         end
     end
 end
 
 #TODO: this is a bit of a hack. We need to find a better way to handle the different types of basis.
-function basis(M::PWCMatrixModel, at::Atoms; join_sites=false, filter=(_,_)->true, T=Float64) 
+function basis(M::PWCMatrixModel, at::Atoms; join_sites=false, filter=(_, _) -> true, T=Float64)
     B = allocate_B(M, at, T)
     basis!(B, M, at, filter)
     return (join_sites ? B[1] : B)
@@ -83,26 +83,26 @@ end
 
 function allocate_B(M::PWCMatrixModel, at::Atoms, T=Float64)
     N = length(at)
-    B_offsite = [spzeros(_block_type(M,T),N,N) for _ =  1:length(M.inds,:offsite)]
+    B_offsite = [spzeros(_block_type(M, T), N, N) for _ = 1:length(M.inds, :offsite)]
     return (offsite=B_offsite,)
 end
 
-function basis!(B, M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, filter=(_,_)->true) where {O3S, Z2S, SC} 
-    site_filter(i,at) = filter(i, at)
+function basis!(B, M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, filter=(_, _) -> true) where {O3S,Z2S,SC}
+    site_filter(i, at) = filter(i, at)
     for (i, neigs, Rs) in sites(at, env_cutoff(M.offsite))
         if site_filter(i, at) && length(neigs) > 0
             Zs = at.Z[neigs]
             # evaluate offsite model
             for (j_loc, j) in enumerate(neigs) #rij, riι
                 if site_filter(j, at)
-                    (Zi, Zj) = _mreduce(at.Z[i],at.Z[j], SC)
-                    if haskey(M.offsite,(Zi,Zj))
-                        sm = M.offsite[(Zi,Zj)]
-                        inds = get_range(M, (Zi,Zj))
+                    (Zi, Zj) = _mreduce(at.Z[i], at.Z[j], SC)
+                    if haskey(M.offsite, (Zi, Zj))
+                        sm = M.offsite[(Zi, Zj)]
+                        inds = get_range(M, (Zi, Zj))
                         cfg = env_transform(j_loc, Rs, Zs, sm.cutoff)
                         Bij = evaluate(sm.linmodel.basis, cfg)
-                        for (k,b) in zip(inds, Bij)
-                            B.offsite[k][i,j] += _val2block(M, b.val)
+                        for (k, b) in zip(inds, Bij)
+                            B.offsite[k][i, j] += _val2block(M, b.val)
                         end
                     end
                 end
@@ -112,50 +112,50 @@ function basis!(B, M::PWCMatrixModel{O3S,<:SphericalCutoff,Z2S,SC}, at::Atoms, f
 end
 
 
-function basis!(B, M::PWCMatrixModel{O3S,<:EllipsoidCutoff,Z2S,SC}, at::Atoms, filter=(_,_)->true) where {O3S, Z2S, SC} 
-    site_filter(i,at) = filter(i, at)
+function basis!(B, M::PWCMatrixModel{O3S,<:EllipsoidCutoff,Z2S,SC}, at::Atoms, filter=(_, _) -> true) where {O3S,Z2S,SC}
+    site_filter(i, at) = filter(i, at)
     if !isempty(M.offsite)
-        for (i, j, rrij, Js, Rs, Zs) in bonds(at, Dict(zz=>cut for (zz,cut) in M.offsite), filter)
-            (Zi, Zj) = _mreduce(at.Z[i],at.Z[j], SC)
+        for (i, j, rrij, Js, Rs, Zs) in bonds(at, Dict(zz => cut for (zz, cut) in M.offsite), filter)
+            (Zi, Zj) = _mreduce(at.Z[i], at.Z[j], SC)
             sm = M.offsite[(Zi, Zj)]
             # transform the ellipse to a sphere
             cfg = env_transform(rrij, Zi, Zj, Rs, Zs, sm.cutoff)
             inds = get_range(M, (Zi, Zj))
             Bij = evaluate(sm.linmodel.basis, cfg)
-            for (k,b) in zip(inds, Bij)
-                B.offsite[k][i,j] += _val2block(M, b.val)
+            for (k, b) in zip(inds, Bij)
+                B.offsite[k][i, j] += _val2block(M, b.val)
             end
         end
     end
 end
 
-function randf(::PWCMatrixModel, Σ::SparseMatrixCSC{SMatrix{3, 3, T, 9}, TI}) where {T<: Real, TI<:Int}
+function randf(::PWCMatrixModel, Σ::SparseMatrixCSC{SMatrix{3,3,T,9},TI}) where {T<:Real,TI<:Int}
     I, J, _ = findnz(Σ)
     Rnz = randn(SVector{3,T}, length(J))
-    R = (sparse(I,J,Rnz) .+ sparse(J,I,Rnz))./sqrt(2)
+    R = (sparse(I, J, Rnz) .+ sparse(J, I, Rnz)) ./ sqrt(2)
     j = unique(J)
-    return vec(sum(Σ.* R, dims=1))
+    return vec(sum(Σ .* R, dims=1))
 end
 
-function randf(::PWCMatrixModel, Σ::SparseMatrixCSC{SVector{3,T}, TI}) where {T<: Real, TI<:Int}
+function randf(::PWCMatrixModel, Σ::SparseMatrixCSC{SVector{3,T},TI}) where {T<:Real,TI<:Int}
     I, J, _ = findnz(Σ)
     Rnz = randn(length(J))
-    R = (sparse(I,J,Rnz) .+ sparse(J,I,Rnz))./sqrt(2)
+    R = (sparse(I, J, Rnz) .+ sparse(J, I, Rnz)) ./ sqrt(2)
     j = unique(J)
-    return vec(sum(Σ.* R, dims=1))
+    return vec(sum(Σ .* R, dims=1))
 end
 
 function ACEfrictionCore.write_dict(M::PWCMatrixModel{O3S,CUTOFF,Z2S,SC}) where {O3S,CUTOFF,Z2S,SC}
     return Dict("__id__" => "ACEfriction_PWCMatrixModel",
-            "offsite" => write_dict(M.offsite),
-            "sc" => write_dict(SC()),
-            #Dict(zz=>write_dict(val) for (zz,val) in M.offsite),
-            "id" => string(M.id))         
+        "offsite" => write_dict(M.offsite),
+        "sc" => write_dict(SC()),
+        #Dict(zz=>write_dict(val) for (zz,val) in M.offsite),
+        "id" => string(M.id))
 end
-function ACEfrictionCore.read_dict(::Val{:ACEfriction_PWCMatrixModel}, D::Dict)
-            offsite = read_dict(D["offsite"])
-            sc = read_dict(D["sc"])
-            #Dict(zz=>read_dict(val) for (zz,val) in D["offsite"])
-            id = Symbol(D["id"])
+function ACEfrictionCore.read_dict(::Val{:ACEfriction_PWCMatrixModel}, D::AbstractDict)
+    offsite = read_dict(D["offsite"])
+    sc = read_dict(D["sc"])
+    #Dict(zz=>read_dict(val) for (zz,val) in D["offsite"])
+    id = Symbol(D["id"])
     return PWCMatrixModel(offsite, id, sc)
 end

--- a/src/patches/acebonds_basisselectors.jl
+++ b/src/patches/acebonds_basisselectors.jl
@@ -3,73 +3,72 @@ using ACEfrictionCore
 
 # export SymmetricEllipsoidBondBasis2
 
-  # explicitly included all optional arguments for transparancy
- function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty; 
-       maxorder::Integer = nothing, 
-       p = 1, 
-       weight = Dict(:l => 1.0, :n => 1.0), 
-       default_maxdeg = nothing,
-       #maxlevels::Dict{Any, Float64} = nothing,
-       r0 = .4, 
-       rin=.0, 
-       trans = polytransform(2, r0), 
-       pcut=2, 
-       pin=2, 
-       bondsymmetry=nothing,
-       filterfun=_->true,
-       kvargs...) # kvargs = additional optional arguments for EllipsoidBondBasis: i.e., species =[:X], isym=:mube, bond_weight = 1.0,  species_minorder_dict = Dict{Any, Float64}(), species_maxorder_dict = Dict{Any, Float64}(), species_weight_cat = Dict(c => 1.0 for c in species), 
-       Bsel = SparseBasis(;  maxorder = maxorder, 
-                         p = p, 
-                         weight = weight, 
-                         default_maxdeg = default_maxdeg)
-                         #maxlevels = maxlevels ) 
-       return SymmetricEllipsoidBondBasis2(ϕ, Bsel; r0=r0, rin=rin,trans=trans, pcut=pcut, pin=pin,bondsymmetry=bondsymmetry, filterfun=filterfun, kvargs...)                 
- end
-
- 
- function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty, Bsel::ACEfrictionCore.SparseBasis; 
-      r0 = .4, 
-      rin=.0, 
-      trans = polytransform(2, r0), 
-      pcut=2, 
-      pin=2, 
-      bondsymmetry=nothing, 
-      species =[:X], 
-      filterfun=_->true,
-      kvargs...
-   )
-   if haskey(kvargs,:isym) 
-      @assert kvargs[:isym] == :mube
-   end
-   @assert 0.0 < r0 < 1.0
-   @assert 0.0 <= rin < 1.0
-
-   BondSelector = EllipsoidBondBasis( Bsel; species=species, kvargs...)
-   min_weight = minimum(values(BondSelector.weight_cat))
-   maxdeg = Int(ceil(maximum(values(BondSelector.maxlevels))))
-   RnYlm = ACEfrictionCore.Utils.RnYlm_1pbasis(;  r0 = r0, 
-      rin = rin,
-      trans = trans, 
-      pcut = pcut,
-      pin = pin, 
-      rcut= 1.0,
-      Bsel = Bsel,
-      maxdeg= maxdeg * max(1,Int(ceil(1/min_weight)))
-   );
-   Bc = ACEfrictionCore.Categorical1pBasis(cat([:bond],species, dims=1); varsym = :mube, idxsym = :mube )
-   B1p =  Bc * RnYlm 
-   return SymmetricEllipsoidBondBasis2(ϕ, BondSelector, B1p; bondsymmetry=bondsymmetry, filterfun=filterfun)
+# explicitly included all optional arguments for transparancy
+function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty;
+    maxorder::Integer=nothing,
+    p=1,
+    weight=Dict(:l => 1.0, :n => 1.0),
+    default_maxdeg=nothing,
+    #maxlevels::AbstractDict{Any, Float64} = nothing,
+    r0=0.4,
+    rin=0.0,
+    trans=polytransform(2, r0),
+    pcut=2,
+    pin=2,
+    bondsymmetry=nothing,
+    filterfun=_ -> true,
+    kvargs...) # kvargs = additional optional arguments for EllipsoidBondBasis: i.e., species =[:X], isym=:mube, bond_weight = 1.0,  species_minorder_dict = Dict{Any, Float64}(), species_maxorder_dict = Dict{Any, Float64}(), species_weight_cat = Dict(c => 1.0 for c in species),
+    Bsel = SparseBasis(; maxorder=maxorder,
+        p=p,
+        weight=weight,
+        default_maxdeg=default_maxdeg)
+    #maxlevels = maxlevels )
+    return SymmetricEllipsoidBondBasis2(ϕ, Bsel; r0=r0, rin=rin, trans=trans, pcut=pcut, pin=pin, bondsymmetry=bondsymmetry, filterfun=filterfun, kvargs...)
 end
 
-function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty, BondSelector::EllipsoidBondBasis, B1p::ACEfrictionCore.Product1pBasis; bondsymmetry=nothing, filterfun = _->true)
-   filterfun_sym = _->true
-   if bondsymmetry == "Even"
-      filterfun_sym = ACEfrictionCore.EvenL(:mube, [:bond])
-   end
-   if bondsymmetry == "Odd"
-      filterfun_sym = x -> !(ACEfrictionCore.EvenL(:mube, [:bond])(x))
-   end
-   filterfun_comb = x -> filterfun(x) && filterfun_sym(x)
-   return ACEfrictionCore.SymmetricBasis(ϕ, B1p, BondSelector; filterfun = filterfun_comb)
+
+function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty, Bsel::ACEfrictionCore.SparseBasis;
+    r0=0.4,
+    rin=0.0,
+    trans=polytransform(2, r0),
+    pcut=2,
+    pin=2,
+    bondsymmetry=nothing,
+    species=[:X],
+    filterfun=_ -> true,
+    kvargs...
+)
+    if haskey(kvargs, :isym)
+        @assert kvargs[:isym] == :mube
+    end
+    @assert 0.0 < r0 < 1.0
+    @assert 0.0 <= rin < 1.0
+
+    BondSelector = EllipsoidBondBasis(Bsel; species=species, kvargs...)
+    min_weight = minimum(values(BondSelector.weight_cat))
+    maxdeg = Int(ceil(maximum(values(BondSelector.maxlevels))))
+    RnYlm = ACEfrictionCore.Utils.RnYlm_1pbasis(; r0=r0,
+        rin=rin,
+        trans=trans,
+        pcut=pcut,
+        pin=pin,
+        rcut=1.0,
+        Bsel=Bsel,
+        maxdeg=maxdeg * max(1, Int(ceil(1 / min_weight)))
+    )
+    Bc = ACEfrictionCore.Categorical1pBasis(cat([:bond], species, dims=1); varsym=:mube, idxsym=:mube)
+    B1p = Bc * RnYlm
+    return SymmetricEllipsoidBondBasis2(ϕ, BondSelector, B1p; bondsymmetry=bondsymmetry, filterfun=filterfun)
 end
 
+function SymmetricEllipsoidBondBasis2(ϕ::ACEfrictionCore.AbstractProperty, BondSelector::EllipsoidBondBasis, B1p::ACEfrictionCore.Product1pBasis; bondsymmetry=nothing, filterfun=_ -> true)
+    filterfun_sym = _ -> true
+    if bondsymmetry == "Even"
+        filterfun_sym = ACEfrictionCore.EvenL(:mube, [:bond])
+    end
+    if bondsymmetry == "Odd"
+        filterfun_sym = x -> !(ACEfrictionCore.EvenL(:mube, [:bond])(x))
+    end
+    filterfun_comb = x -> filterfun(x) && filterfun_sym(x)
+    return ACEfrictionCore.SymmetricBasis(ϕ, B1p, BondSelector; filterfun=filterfun_comb)
+end

--- a/src/utils/basisutils.jl
+++ b/src/utils/basisutils.jl
@@ -1,9 +1,9 @@
 using ACEfrictionCore
 export modify_Rn, modify_species
 
-function modify_Rn(basis::ACEfrictionCore.SymmetricBasis; kwargs... ) 
+function modify_Rn(basis::ACEfrictionCore.SymmetricBasis; kwargs...)
     maxdeg = length(basis.pibasis.basis1p["Rn"])
-    Rn_new = ACEfrictionCore.Utils.Rn_basis(; maxdeg = maxdeg, kwargs...) 
+    Rn_new = ACEfrictionCore.Utils.Rn_basis(; maxdeg=maxdeg, kwargs...)
     return modify_Rn(basis, Rn_new)
 end
 
@@ -18,17 +18,17 @@ function modify_Rn(basis::ACEfrictionCore.SymmetricBasis, Rn_new::ACEfrictionCor
         end
     end
     @assert ci !== 0
-    B1p_new = ACEfrictionCore.Product1pBasis( Tuple((i == ci ? Rn_new : b) for (i,b) in enumerate(B1p.bases)),
-                              B1p.indices, B1p.B_pool)
-    pibasis_new = PIBasis(B1p_new, basis.pibasis.spec, basis.pibasis.real)  
-    return ACEfrictionCore.SymmetricBasis(pibasis_new,basis.A2Bmap,basis.symgrp,basis.real)
+    B1p_new = ACEfrictionCore.Product1pBasis(Tuple((i == ci ? Rn_new : b) for (i, b) in enumerate(B1p.bases)),
+        B1p.indices, B1p.B_pool)
+    pibasis_new = PIBasis(B1p_new, basis.pibasis.spec, basis.pibasis.real)
+    return ACEfrictionCore.SymmetricBasis(pibasis_new, basis.A2Bmap, basis.symgrp, basis.real)
 end
 
 """wraper for modify_categories that can be used to simplify replacing atom species in the case of bond and non-bond environments"""
-function modify_species(basis::ACEfrictionCore.SymmetricBasis, swap_dict::Dict, bond::Bool) 
+function modify_species(basis::ACEfrictionCore.SymmetricBasis, swap_dict::AbstractDict, bond::Bool)
     if bond
-        varsym=:mube
-        idxsym=:mube
+        varsym = :mube
+        idxsym = :mube
     else
         varsym = :mu
         idxsym = :mu
@@ -37,10 +37,10 @@ function modify_species(basis::ACEfrictionCore.SymmetricBasis, swap_dict::Dict, 
     return modify_categories(basis, swap_dict; varsym=varsym, idxsym=idxsym)
 end
 
-function modify_categories(basis::ACEfrictionCore.SymmetricBasis, swap_dict::Dict; varsym=:mu, idxsym=:mu)
+function modify_categories(basis::ACEfrictionCore.SymmetricBasis, swap_dict::AbstractDict; varsym=:mu, idxsym=:mu)
     B1p = basis.pibasis.basis1p
-    new_categories = [ (haskey(swap_dict,c) ? swap_dict[c] : c) for c in B1p["C$(idxsym)"].categories.list ]
-    Bc_new = ACEfrictionCore.Categorical1pBasis(new_categories; varsym = varsym, idxsym = idxsym)
+    new_categories = [(haskey(swap_dict, c) ? swap_dict[c] : c) for c in B1p["C$(idxsym)"].categories.list]
+    Bc_new = ACEfrictionCore.Categorical1pBasis(new_categories; varsym=varsym, idxsym=idxsym)
     @assert length(Bc_new) == length(B1p["C$(idxsym)"]) "length of Bc_new = $(length(Bc_new)) vs $(length(B1p["C$(idxsym)"]))"
     ci = 0
     for i = 1:length(B1p)
@@ -50,9 +50,8 @@ function modify_categories(basis::ACEfrictionCore.SymmetricBasis, swap_dict::Dic
         end
     end
     @assert ci !== 0 "No categegorical 1p basis with identifier C$(idxsym) found."
-    B1p_new = ACEfrictionCore.Product1pBasis( Tuple((i == ci ? Bc_new : b) for (i,b) in enumerate(B1p.bases)),
-                              B1p.indices, B1p.B_pool)
-    pibasis_new = PIBasis(B1p_new, basis.pibasis.spec, basis.pibasis.real)  
-    return ACEfrictionCore.SymmetricBasis(pibasis_new,basis.A2Bmap,basis.symgrp,basis.real)
+    B1p_new = ACEfrictionCore.Product1pBasis(Tuple((i == ci ? Bc_new : b) for (i, b) in enumerate(B1p.bases)),
+        B1p.indices, B1p.B_pool)
+    pibasis_new = PIBasis(B1p_new, basis.pibasis.spec, basis.pibasis.real)
+    return ACEfrictionCore.SymmetricBasis(pibasis_new, basis.A2Bmap, basis.symgrp, basis.real)
 end
-


### PR DESCRIPTION
Since JSON v1 uses `JSON.Object` type dictionaries instead of initializing `Dict`s now, I made a bunch of functions work with any `AbstractDict` instead. 

Sorry in advance for the merge conflicts due to formatting. 